### PR TITLE
Apply misc. fixes and add View:consume

### DIFF
--- a/src/Manifest.lua
+++ b/src/Manifest.lua
@@ -515,15 +515,6 @@ end
 
 --[[
 
-	Clear the underlying storage for components of the given type.
-
-]]
-function Manifest:clear(id)
-	self:_getPool(id):clear()
-end
-
---[[
-
 	Return the number of entities currently in use.
 
 ]]

--- a/src/Manifest.spec.lua
+++ b/src/Manifest.spec.lua
@@ -157,6 +157,28 @@ return function()
 			expect(manifest:createFrom(50)).to.equal(50)
 		end)
 
+		it("should properly remove an entity from the stack of recyclable entities", function(context)
+			local manifest = context.manifest
+
+			for _ = 1, numEntities do
+				manifest:create()
+			end
+
+			manifest:destroy(2)
+			manifest:destroy(4)
+			manifest:destroy(16)
+			manifest:destroy(32)
+			manifest:destroy(64)
+
+			expect(manifest:createFrom(16)).to.equal(16)
+			expect(manifest:createFrom(bit32.bor(64, bit32.lshift(16, Constants.ENTITYID_WIDTH))))
+				.to.equal(bit32.bor(64, bit32.lshift(16, Constants.ENTITYID_WIDTH)))
+			expect(manifest:createFrom(4)).to.equal(4)
+
+			expect(bit32.band(manifest:create(), Constants.ENTITYID_MASK)).to.equal(32)
+			expect(bit32.band(manifest:create(), Constants.ENTITYID_MASK)).to.equal(2)
+		end)
+
 		it("should return a brand new entity identifier when the entity id is in use", function(context)
 			for _ = 1, numEntities do
 				context.manifest:create()

--- a/src/Matcher.lua
+++ b/src/Matcher.lua
@@ -20,14 +20,6 @@ local function append(source, destination)
 	move(source, 1, #source, #destination + 1, destination)
 end
 
-function Matcher.new()
-	return setmetatable({
-		required = {},
-		forbidden = {},
-		changed = {}
-	}, Matcher)
-end
-
 function Matcher:all(...)
 	append({ ... }, self.required)
 

--- a/src/Observer.lua
+++ b/src/Observer.lua
@@ -36,13 +36,15 @@ local function maybeRemove(pool)
 end
 
 function Observer.new(manifest, id, pool)
-	local observer = Matcher.new()
+	return setmetatable({
+		manifest = manifest,
+		id = id,
+		pool = pool,
 
-	observer.manifest = manifest
-	observer.id = id
-	observer.pool = pool
-
-	return setmetatable(observer, Observer)
+		required = {},
+		forbidden = {},
+		changed = {}
+	}, Observer)
 end
 
 function Observer:__call()

--- a/src/Pool.lua
+++ b/src/Pool.lua
@@ -11,13 +11,13 @@ Pool.__index = Pool
 
 local function componentTypeOk(underlyingType, component)
 	local ty = typeof(component)
-	local ok = true
+	local instanceTypeOk = false
 
 	if ty == "Instance" then
-		ok = component:IsA(underlyingType)
+		instanceTypeOk = component:IsA(underlyingType)
 	end
 
-	return (tostring(underlyingType) == ty) or ok,
+	return (tostring(underlyingType) == ty) or instanceTypeOk,
 	ErrBadType:format(tostring(underlyingType), typeof(component))
 end
 

--- a/src/Pool.lua
+++ b/src/Pool.lua
@@ -66,7 +66,7 @@ function Pool:assign(entity, component)
 	self.dense[size] = entity
 	self.sparse[bit32.band(entity, ENTITYID_MASK)] = size
 
-	if self.underlyingType then
+	if component then
 		self.objects[size] = component
 
 		return component

--- a/src/Pool.lua
+++ b/src/Pool.lua
@@ -93,20 +93,4 @@ function Pool:destroy(entity)
 	end
 end
 
-function Pool:clear()
-	-- does this pool contain tag components?
-	if self.underlyingType then
-		for i, entity in ipairs(self.sparse) do
-			self.dense[i] = nil
-			self.sparse[entity] = nil
-			self.objects[i] = nil
-		end
-	else
-		for i, entity in ipairs(self.dense) do
-			self.dense[i] = nil
-			self.sparse[entity] = nil
-		end
-	end
-end
-
 return Pool

--- a/src/View.lua
+++ b/src/View.lua
@@ -129,10 +129,10 @@ end
 
 function Single:forEach(func)
 	local pool = self.required[1]
-	local objs = pool.objects
+	local objects = pool.objects
 
 	for index, entity in ipairs(pool.dense) do
-		func(entity, objs[index])
+		func(entity, objects[index])
 	end
 end
 

--- a/src/View.lua
+++ b/src/View.lua
@@ -1,5 +1,7 @@
 local Matcher = require(script.Parent.Matcher)
 
+local EMPTY = {}
+
 local View = {}
 View.__index = Matcher
 
@@ -140,6 +142,20 @@ function Single:forEachEntity(func)
 	for _, entity in ipairs(self.required[1].dense) do
 		func(entity)
 	end
+end
+
+function Single:consume(func)
+	local pool = self.required[1]
+
+	for _, entity in ipairs(pool.dense) do
+		func(entity)
+		pool.sparse[entity] = nil
+	end
+
+	table.move(EMPTY, 1, #pool.dense, pool.dense)
+	table.move(EMPTY, 1, #pool.objects, pool.objects)
+
+	pool.size = 0
 end
 
 function MultiWithForbidden:forEach(func)


### PR DESCRIPTION
`View:consume` (only avail is intended to replace `Manifest:clear` when one wishes to reset a pool: for example, when iterating over an observer's pool. This makes it the only method of `View` which can mutate the pool which the `View` is iterating - might be funky?