### PR TITLE
Change the loader again

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -1,14 +1,17 @@
 local Manifest = require(script.Manifest)
 
-return function(projectRoot)
-	local components = projectRoot:FindFirstChild("Components")
+return function()
 	local ecs = Manifest.new()
 
-	for _, instance in ipairs(components:GetDescendants()) do
-		if instance:IsA("ModuleScript") then
-			require(instance)(ecs)
-		end
-	end
+	return {
+		ecs = ecs
 
-	return ecs
+		define = function(componentsRoot)
+			for _, instance in ipairs(componentsRoot:GetDescendants()) do
+				if instance:IsA("ModuleScript") then
+					ecs:define(require(instance))
+				end
+			end
+		end
+	}
 end


### PR DESCRIPTION
init.lua now returns a function that returns a table containing the fields:

* define, a utility function that requires all modules in the given root directory;
* ecs, a new instance of Manifest.