### PR TITLE
Type introspection

### DIFF
--- a/src/Core/Type.lua
+++ b/src/Core/Type.lua
@@ -1,0 +1,128 @@
+--[[
+
+	Wrapper around t that lets us inspect detailed type information after the
+	fact.
+
+]]
+
+local t = require(script.Parent.Parent.t)
+
+local firstOrder = {
+	boolean = true,
+	none = true,
+	string = true,
+	table = true,
+	number = true,
+	nan = true,
+	integer = true,
+	Axes = true,
+	BrickColor = true,
+	CFrame = true,
+	Color3 = true,
+	ColorSequence = true,
+	ColorSequenceKeypoint = true,
+	DockWidgetPluginGuiInfo = true,
+	Faces = true,
+	Instance = true,
+	NumberRange = true,
+	NumberSequence = true,
+	NumberSequenceKeypoint = true,
+	PathWaypoint = true,
+	PhysicalProperties = true,
+	Random = true,
+	Ray = true,
+	Rect = true,
+	Region3 = true,
+	Region3int16 = true,
+	TweenInfo = true,
+	UDim = true,
+	UDim2 = true,
+	Vector2 = true,
+	Vector3 = true,
+	Vector3int16 = true,
+	Enum = true,
+	EnumItem = true,
+	numberPositive = true,
+	numberNegative = true,
+}
+
+local secondOrder = {
+	literal = true,
+	keyOf = true,
+	valueOf = true,
+	integer = true,
+	numberMin = true,
+	numberMax = true,
+	numberMinExclusive = true,
+	numberMaxExclusive = true,
+	numberConstrained = true,
+	numberConstrainedExclusive = true,
+	match = true,
+	keys = true,
+	values = true,
+	map = true,
+	set = true,
+	array = true,
+	strictArray = true,
+	union = true,
+	some  = true,
+	intersection = true,
+	every  = true,
+	interface = true,
+	strictInterface = true,
+	instanceOf = true,
+	instanceIsA = true,
+	enum = true,
+	wrap = true,
+	strict = true,
+}
+
+local concrete = {
+	match = "string",
+	numberMin = "number",
+	numberMax = "number",
+	numberMinExclusive = "number",
+	numberMaxExclusive =  "number",
+	numberConstrained = "number",
+	numberConstrainedExclusive = "number",
+	numberPositive = "number",
+	numberNegative = "number",
+}
+
+local function getConcrete(typeName)
+	return
+		concrete[typeName]
+		or (firstOrder[typeName] and typeName)
+end
+
+local function unwrap(...)
+	local unwrapped = table.create(select("#", ...))
+
+	for i = 1, select("#", ...) do
+		unwrapped[i] = select(i, ...).check or select(i, ...)
+	end
+
+	return unpack(unwrapped)
+end
+
+local Type = {}
+
+for typeName in pairs(t) do
+	if firstOrder[typeName] ~= nil then
+		Type[typeName] = {
+			check = t[typeName],
+			name = typeName,
+			concrete = getConcrete(typeName),
+		}
+	elseif secondOrder[typeName] ~= nil then
+		Type[typeName] = function(...)
+			return {
+				args = { ... },
+				check = t[typeName](unwrap(...)),
+				name = typeName,
+			}
+		end
+	end
+end
+
+return Type

--- a/src/Core/Type.spec.lua
+++ b/src/Core/Type.spec.lua
@@ -1,0 +1,47 @@
+return function()
+	local Type = require(script.Parent.Type)
+	local t = require(script.Parent.Parent.t)
+
+	FOCUS()
+
+	it("should return a primitive definition for first-order functions", function()
+		local ty = Type.Vector3
+
+		expect(ty).to.be.a("table")
+		expect(ty.check).to.equal(t.Vector3)
+		expect(ty.concrete).to.equal("Vector3")
+		expect(ty.name).to.equal("Vector3")
+	end)
+
+	it("should return a compound definition for second-order functions", function()
+		local ty = Type.instanceIsA("BasePart")
+
+		expect(ty).to.be.a("table")
+		expect(ty.args).to.be.a("table")
+		expect(ty.args[1]).to.equal("BasePart")
+		expect(ty.check).to.be.a("function")
+		expect(ty.name).to.equal("instanceIsA")
+	end)
+
+	it("should return a compound definition for second-order functions that take functions as arguments", function()
+		local ty = Type.union(Type.literal("string1"), Type.literal("string2"))
+
+		expect(ty).to.be.a("table")
+		expect(ty.args).to.be.a("table")
+		expect(ty.check).to.be.a("function")
+		expect(ty.name).to.equal("union")
+
+		local args = ty.args
+		local string1 = args[1]
+		local string2 = args[2]
+
+		expect(string1).to.be.a("table")
+		expect(string2).to.be.a("table")
+		expect(string1.check).to.be.a("function")
+		expect(string2.check).to.be.a("function")
+		expect(string1.args[1]).to.equal("string1")
+		expect(string2.args[1]).to.equal("string2")
+		expect(string1.name).to.equal("literal")
+		expect(string2.name).to.equal("literal")
+	end)
+end

--- a/src/Core/Type.spec.lua
+++ b/src/Core/Type.spec.lua
@@ -2,8 +2,6 @@ return function()
 	local Type = require(script.Parent.Type)
 	local t = require(script.Parent.Parent.t)
 
-	FOCUS()
-
 	it("should return a primitive definition for first-order functions", function()
 		local ty = Type.Vector3
 


### PR DESCRIPTION
The plugin will need to examine component type information in order to write to attributes. This PR implements a wrapper around `t` that provides this functionality.