### PR TITLE
Add RemoteEntityMap

### DIFF
--- a/lib/src/Core/Constants.lua
+++ b/lib/src/Core/Constants.lua
@@ -6,5 +6,6 @@ return {
 	EntityIdWidth = EntityIdWidth,
 	EntityAttributeName = "__entity",
 	InstanceRefFolder = "__anattaRefs",
+	SharedInstanceTagName = ".anattaSharedInstance",
 	NullEntityId = 0,
 }

--- a/lib/src/Dom/init.lua
+++ b/lib/src/Dom/init.lua
@@ -2,10 +2,12 @@ local tryFromDom = require(script.tryFromDom)
 local tryFromAttribute = require(script.tryFromAttribute)
 local tryFromTag = require(script.tryFromTag)
 local tryToAttribute = require(script.tryToAttribute)
+local waitForRefs = require(script.waitForRefs)
 
 return {
 	tryFromAttribute = tryFromAttribute,
 	tryFromDom = tryFromDom,
 	tryFromTag = tryFromTag,
 	tryToAttribute = tryToAttribute,
+	waitForRefs = waitForRefs,
 }

--- a/lib/src/Dom/waitForRefs.lua
+++ b/lib/src/Dom/waitForRefs.lua
@@ -1,0 +1,31 @@
+local Constants = require(script.Parent.Parent.Core.Constants)
+
+local INSTANCE_REF_FOLDER = Constants.InstanceRefFolder
+
+local function waitForRefs(instance, attributeName, typeDefinition, objectValues)
+	local _, concreteType = typeDefinition:tryGetConcreteType()
+	local refFolder = instance:WaitForChild(INSTANCE_REF_FOLDER)
+
+	objectValues = objectValues or {}
+
+	if typeof(concreteType) == "table" then
+		for field in pairs(concreteType) do
+			local fieldAttributeName = ("%s_%s"):format(attributeName, field)
+			local fieldTypeDefinition = typeDefinition.typeParams[1][field]
+
+			waitForRefs(instance, fieldAttributeName, fieldTypeDefinition, objectValues)
+		end
+	elseif concreteType == "instanceOf" or concreteType == "instanceIsA" then
+		local objectValue = refFolder:WaitForChild(attributeName)
+
+		if objectValue.Value == nil then
+			objectValue.Changed:Wait()
+		end
+
+		table.insert(objectValues, objectValue)
+	end
+
+	return objectValues
+end
+
+return waitForRefs

--- a/lib/src/RemoteEntityMap/init.lua
+++ b/lib/src/RemoteEntityMap/init.lua
@@ -1,0 +1,43 @@
+local withSharedInstances = require(script.withSharedInstances)
+
+local RemoteEntityMap = {}
+RemoteEntityMap.__index = RemoteEntityMap
+
+function RemoteEntityMap.new(registry)
+	return setmetatable({
+		registry = registry,
+		localEntitiesByRemote = {},
+		remoteEntitiesByLocal = {},
+	}, RemoteEntityMap)
+end
+
+function RemoteEntityMap:add(remoteEntity)
+	local localEntity = self.registry:create()
+
+	self.remoteEntitiesByLocal[localEntity] = remoteEntity
+	self.localEntitiesByRemote[remoteEntity] = localEntity
+
+	return localEntity
+end
+
+function RemoteEntityMap:remove(remoteEntity)
+	local localEntity = self.localEntitiesByRemote[remoteEntity]
+
+	self.registry:destroy(localEntity)
+	self.remoteEntitiesByLocal[localEntity] = nil
+	self.localEntitiesByRemote[remoteEntity] = nil
+end
+
+function RemoteEntityMap:getLocal(remoteEntity)
+	return self.localEntitiesByRemote[remoteEntity]
+end
+
+function RemoteEntityMap:getRemote(localEntity)
+	return self.remoteEntitiesByLocal[localEntity]
+end
+
+function RemoteEntityMap:withSharedInstances()
+	withSharedInstances(self)
+end
+
+return RemoteEntityMap

--- a/lib/src/RemoteEntityMap/withSharedInstances/client.lua
+++ b/lib/src/RemoteEntityMap/withSharedInstances/client.lua
@@ -1,0 +1,93 @@
+local CollectionService = game:GetService("CollectionService")
+
+local Constants = require(script.Parent.Parent.Parent.Core.Constants)
+local Dom = require(script.Parent.Parent.Parent.Dom)
+
+local ENTITY_ATTRIBUTE_NAME = Constants.EntityAttributeName
+local SHARED_INSTANCE_TAG_NAME = Constants.SharedInstanceTagName
+
+return function(remoteEntityMap)
+	local registry = remoteEntityMap.registry
+	local sharedInstances = CollectionService:GetTagged(SHARED_INSTANCE_TAG_NAME)
+	local connectedListeners = {}
+
+	local function adorn(localEntity, sharedInstance)
+		local connections = {}
+
+		for _, componentName in ipairs(CollectionService:GetTags(sharedInstance)) do
+			if not registry:hasDefined(componentName) then
+				continue
+			end
+
+			local typeDefinition = registry:getDefinition(componentName)
+			local objectValues = Dom.waitForRefs(sharedInstance, componentName, typeDefinition)
+
+			for _, objectValue in ipairs(objectValues) do
+				if objectValue.Value == sharedInstance then
+					-- If the reference is to the shared Instance, then it is definitely
+					-- valid right now. It will remain valid at least until the shared
+					-- Instance is removed (whether by tag removal, being streamed out,
+					-- destruction, etc.), so nothing more must be done in this case.
+					continue
+				end
+
+				-- Otherwise, this ObjectValue must be observed to ensure that the
+				-- Registry never contains an invalid reference.
+				table.insert(
+					connections,
+					objectValue.Changed:Connect(function(ref)
+						if ref == nil then
+							registry:tryRemove(localEntity, componentName)
+						else
+							local success, component = Dom.tryFromAttribute(
+								sharedInstance,
+								componentName,
+								typeDefinition
+							)
+
+							if success then
+								registry:tryAdd(localEntity, componentName, component)
+							end
+						end
+					end)
+				)
+			end
+
+			connectedListeners[sharedInstance] = connections
+
+			local _, component = Dom.tryFromAttribute(sharedInstance, componentName, typeDefinition)
+
+			registry:tryAdd(localEntity, componentName, component)
+		end
+	end
+
+	for _, sharedInstance in ipairs(sharedInstances) do
+		local remoteEntity = sharedInstance:GetAttribute(ENTITY_ATTRIBUTE_NAME)
+		local localEntity = remoteEntityMap:add(remoteEntity)
+
+		task.defer(adorn, localEntity, sharedInstance)
+	end
+
+	-- Both of these connections will leak after a hot reload, but it's probably ok?
+
+	CollectionService
+		:GetInstanceAddedSignal(SHARED_INSTANCE_TAG_NAME)
+		:Connect(function(sharedInstance)
+			local remoteEntity = sharedInstance:GetAttribute(ENTITY_ATTRIBUTE_NAME)
+			local localEntity = remoteEntityMap:add(remoteEntity)
+
+			adorn(localEntity, sharedInstance)
+		end)
+
+	CollectionService
+		:GetInstanceRemovedSignal(SHARED_INSTANCE_TAG_NAME)
+		:Connect(function(sharedInstance)
+			local remoteEntity = sharedInstance:GetAttribute(ENTITY_ATTRIBUTE_NAME)
+
+			remoteEntityMap:remove(remoteEntity)
+
+			for _, connection in ipairs(connectedListeners[sharedInstance]) do
+				connection:Disconnect()
+			end
+		end)
+end

--- a/lib/src/RemoteEntityMap/withSharedInstances/init.lua
+++ b/lib/src/RemoteEntityMap/withSharedInstances/init.lua
@@ -1,0 +1,12 @@
+local RunService = game:GetService("RunService")
+
+local client = require(script.client)
+local server = require(script.server)
+
+return function(remoteEntityMap)
+	if RunService:IsClient() then
+		client(remoteEntityMap)
+	elseif RunService:IsServer() then
+		server(remoteEntityMap)
+	end
+end

--- a/lib/src/RemoteEntityMap/withSharedInstances/server.lua
+++ b/lib/src/RemoteEntityMap/withSharedInstances/server.lua
@@ -1,0 +1,19 @@
+local CollectionService = game:GetService("CollectionService")
+
+local Constants = require(script.Parent.Parent.Parent.Core.Constants)
+local Type = require(script.Parent.Parent.Parent.Core.Type)
+
+local ENTITY_ATTRIBUTE_NAME = Constants.EntityAttributeName
+local SHARED_INSTANCE_TAG_NAME = Constants.SharedInstanceTagName
+
+return function(remoteEntityMap)
+	local registry = remoteEntityMap.registry
+	local sharedInstances = CollectionService:GetTagged(SHARED_INSTANCE_TAG_NAME)
+
+	registry:define("SharedInstance", Type.Instance)
+
+	for _, instance in ipairs(sharedInstances) do
+		local entity = instance:GetAttribute(ENTITY_ATTRIBUTE_NAME)
+		registry:add(entity, "SharedInstance", instance)
+	end
+end

--- a/lib/src/init.lua
+++ b/lib/src/init.lua
@@ -1,7 +1,7 @@
 local Dom = require(script.Dom)
 local Entity = require(script.Entity)
 local Loader = require(script.Loader)
-local Network = require(script.Network)
+local RemoteEntityMap = require(script.RemoteEntityMap)
 local System = require(script.System)
 local Type = require(script.Core.Type)
 
@@ -9,7 +9,7 @@ return {
 	Dom = Dom,
 	Entity = Entity,
 	Loader = Loader,
-	Network = Network,
+	RemoteEntityMap = RemoteEntityMap,
 	System = System,
 	t = Type,
 }

--- a/plugin/src/Constants.lua
+++ b/plugin/src/Constants.lua
@@ -4,6 +4,7 @@ local privatePrefix = ".anatta"
 
 return {
 	EntityAttributeName = Constants.EntityAttributeName,
+	SharedInstanceTagName = Constants.SharedInstanceTagName,
 	DefinitionModuleTagName = "AnattaComponentDefinitions",
 	PluginPrivateComponentPrefix = privatePrefix,
 	PendingValidation = privatePrefix .. "Pending%s",

--- a/plugin/src/Main.lua
+++ b/plugin/src/Main.lua
@@ -9,6 +9,7 @@ local t = Anatta.t
 local ENTITY_ATTRIBUTE_NAME = Constants.EntityAttributeName
 local DEFINITION_MODULE_TAG_NAME = Constants.DefinitionModuleTagName
 local PENDING_VALIDATION = Constants.PendingValidation
+local SHARED_INSTANCE_TAG_NAME = Constants.SharedInstanceTagName
 
 local function loadDefinition(moduleScript, loader, plugin)
 	if not moduleScript:IsA("ModuleScript") then
@@ -84,7 +85,7 @@ return function(plugin, saveState)
 		if not success then
 			warn(result)
 		else
-			for _, instance in ipairs(CollectionService:GetTagged(".anattaInstance")) do
+			for _, instance in ipairs(CollectionService:GetTagged(SHARED_INSTANCE_TAG_NAME)) do
 				local entity = instance:GetAttribute(ENTITY_ATTRIBUTE_NAME)
 
 				if loader.registry:valid(entity) then

--- a/plugin/src/Systems/Entity.lua
+++ b/plugin/src/Systems/Entity.lua
@@ -4,6 +4,7 @@ local RunService = game:GetService("RunService")
 local Constants = require(script.Parent.Parent.Constants)
 
 local ENTITY_ATTRIBUTE_NAME = Constants.EntityAttributeName
+local SHARED_INSTANCE_TAG_NAME = Constants.SharedInstanceTagName
 
 return function(system)
 	local registry = system.registry
@@ -12,12 +13,12 @@ return function(system)
 
 	system:on(instances.added, function(entity, instance)
 		instance:SetAttribute(ENTITY_ATTRIBUTE_NAME, entity)
-		CollectionService:AddTag(instance, ".anattaInstance")
+		CollectionService:AddTag(instance, SHARED_INSTANCE_TAG_NAME)
 	end)
 
 	system:on(instances.removed, function(_, instance)
 		instance:SetAttribute(ENTITY_ATTRIBUTE_NAME, nil)
-		CollectionService:RemoveTag(instance, ".anattaInstance")
+		CollectionService:RemoveTag(instance, SHARED_INSTANCE_TAG_NAME)
 	end)
 
 	system:on(RunService.Heartbeat, function()


### PR DESCRIPTION
This module is intended to standardize the process of networking a
registry. It's a bidirectional map between local and remote entities
that currently exposes the following methods:

* RemoteEntityMap.new(registry)

	Create a new RemoteEntityMap given a local registry.

* RemoteEntityMap:add(remoteEntity)

	Create a new entity in the local registry and associate it with a
	given remote entity and return the newly created local entity.

* RemoteEntityMap:remove(remoteEntity)

	Destroy the local entity associated with the given remote entity
	and remote them both from the RemoteEntityMap.

* RemoteEntityMap:getLocal(remoteEntity)

	Return the local entity associated with the given remote
	entity. Return nil if there is no local entity associated with
	the remote entity.

* RemoteEntityMap:getRemote(localEntity)

	Return the remote entity associated with the given local
	entity. Return nil if there is no remote entity associated with
	the local entity.

* RemoteEntityMap:withSharedInstances()

	Enable "shared Instances." These are Instances that have entity
	component data stored in attributes (for example, Instances that
	were marked up in Anatta's Roblox Studio plugin).

	This method has different behavior depending if its called on the
	client or the server.

	On the client, it starts listening for shared Instances entering
	the DataModel. Their respective entities will be constructed and
	destructed as necessary.

	On the server, it defines the component "SharedInstance" (of type
	Instance) and adds it to associated entity.