### PR TITLE
Move error handling for queries to World

### DIFF
--- a/lib/src/World/Mapper.lua
+++ b/lib/src/World/Mapper.lua
@@ -12,24 +12,18 @@
 
 local SingleMapper = require(script.Parent.SingleMapper)
 local Types = require(script.Parent.Parent.Types)
+
 local util = require(script.Parent.Parent.util)
 
 local Mapper = {}
 Mapper.__index = Mapper
-
-local ErrCantHaveUpdated = "Mappers cannot track updates to components"
-local ErrNeedComponents = "Mappers need at least one required component type"
 
 function Mapper.new(registry, query)
 	util.jumpAssert(Types.Query(query))
 
 	local withAll = query.withAll or {}
 	local withAny = query.withAny or {}
-	local withUpdated = query.withUpdated or {}
 	local without = query.without or {}
-
-	util.jumpAssert(#withUpdated == 0, ErrCantHaveUpdated)
-	util.jumpAssert(#withAll > 0, ErrNeedComponents)
 
 	if #without == 0 and #withAny == 0 and #withAll == 1 then
 		return SingleMapper.new(registry:getPool(query.withAll[1]))

--- a/lib/src/World/Reactor.lua
+++ b/lib/src/World/Reactor.lua
@@ -20,9 +20,6 @@ local Types = require(script.Parent.Parent.Types)
 
 local util = require(script.Parent.Parent.util)
 
-local ErrNeedComponents = "Reactors need at least one required, updated, or optional component type"
-local ErrTooManyUpdated = "Reactors can only track up to 32 updated component types"
-
 local Reactor = {}
 Reactor.__index = Reactor
 
@@ -40,9 +37,6 @@ function Reactor.new(registry, query)
 	local withUpdated = query.withUpdated or {}
 	local without = query.without or {}
 	local withAny = query.withAny or {}
-
-	util.jumpAssert(#withUpdated <= 32, ErrTooManyUpdated)
-	util.jumpAssert(#withAll > 0 or #withUpdated > 0 or #withAny > 0, ErrNeedComponents)
 
 	if #withAll == 1 and #withUpdated == 0 and #without == 0 and #withAny == 0 then
 		return SingleReactor.new(registry:getPool(query.withAll[1]))


### PR DESCRIPTION
Previously, queries were validated in the constructors of `Reactor` and `Mapper`. This PR moves this error handling to `World` so we can provide a better error message to the user.