### PR TITLE
Use ComponentDefinitions instead of strings for registry methods

### DIFF
--- a/lib/src/Types.lua
+++ b/lib/src/Types.lua
@@ -13,10 +13,10 @@ local ComponentDefinition = t.strictInterface({
 })
 
 local Query = t.strictInterface({
-	withAll = t.optional(t.array(t.string)),
-	withUpdated = t.optional(t.array(t.string)),
-	withAny = t.optional(t.array(t.string)),
-	without = t.optional(t.array(t.string)),
+	withAll = t.optional(t.array(ComponentDefinition)),
+	withUpdated = t.optional(t.array(ComponentDefinition)),
+	withAny = t.optional(t.array(ComponentDefinition)),
+	without = t.optional(t.array(ComponentDefinition)),
 })
 
 return {

--- a/lib/src/World/Mapper.spec.lua
+++ b/lib/src/World/Mapper.spec.lua
@@ -4,33 +4,35 @@ return function()
 	local Registry = require(script.Parent.Registry)
 	local T = require(script.Parent.Parent.Core.T)
 
+	local Component = {
+		Test1 = {
+			name = "Test1",
+			type = T.table,
+		},
+		Test2 = {
+			name = "Test2",
+			type = T.table,
+		},
+		Test3 = {
+			name = "Test3",
+			type = T.table,
+		},
+		Test4 = {
+			name = "Test4",
+			type = T.table,
+		},
+		TestTag = {
+			name = "TestTag",
+			type = T.none,
+		},
+	}
+
 	beforeEach(function(context)
 		local registry = Registry.new()
 
-		registry:defineComponent({
-			name = "Test1",
-			type = T.table,
-		})
-
-		registry:defineComponent({
-			name = "Test2",
-			type = T.table,
-		})
-
-		registry:defineComponent({
-			name = "Test3",
-			type = T.table,
-		})
-
-		registry:defineComponent({
-			name = "Test4",
-			type = T.table,
-		})
-
-		registry:defineComponent({
-			name = "TestTag",
-			type = T.none,
-		})
+		for _, definition in pairs(Component) do
+			registry:defineComponent(definition)
+		end
 
 		context.registry = registry
 	end)
@@ -43,20 +45,20 @@ return function()
 			local entity = registry:createEntity()
 
 			if i % 2 == 0 then
-				registry:addComponent(entity, "Test1", {})
-				registry:addComponent(entity, "TestTag")
+				registry:addComponent(entity, Component.Test1, {})
+				registry:addComponent(entity, Component.TestTag)
 			end
 
 			if i % 3 == 0 then
-				registry:addComponent(entity, "Test2", {})
+				registry:addComponent(entity, Component.Test2, {})
 			end
 
 			if i % 4 == 0 then
-				registry:addComponent(entity, "Test3", {})
+				registry:addComponent(entity, Component.Test3, {})
 			end
 
 			if i % 5 == 0 then
-				registry:addComponent(entity, "Test4", {})
+				registry:addComponent(entity, Component.Test4, {})
 			end
 
 			if
@@ -73,8 +75,8 @@ return function()
 	describe("new", function()
 		it("should create a new Mapper when there are  multiple components", function(context)
 			local mapper = Mapper.new(context.registry, {
-				withAll = { "Test1" },
-				without = { "Test2" },
+				withAll = { Component.Test1 },
+				without = { Component.Test2 },
 			})
 
 			expect(getmetatable(mapper)).to.equal(Mapper)
@@ -84,7 +86,7 @@ return function()
 			"should create a new SingleMapper when there is only one required component ",
 			function(context)
 				local mapper = Mapper.new(context.registry, {
-					withAll = { "Test1" },
+					withAll = { Component.Test1 },
 				})
 
 				expect(getmetatable(mapper)).to.equal(SingleMapper)
@@ -99,16 +101,16 @@ return function()
 				function(context)
 					local registry = context.registry
 					local mapper, toIterate = createTestMapper(registry, {
-						withAll = { "Test1", "Test2" },
-						withAny = { "Test3", "Test4" },
+						withAll = { Component.Test1, Component.Test2 },
+						withAny = { Component.Test3, Component.Test4 },
 					})
 
 					mapper:map(function(entity, test1, test2, test3, test4)
 						expect(toIterate[entity]).to.equal(true)
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
-						expect(test3).to.equal(registry:getComponent(entity, "Test3"))
-						expect(test4).to.equal(registry:getComponent(entity, "Test4"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
+						expect(test3).to.equal(registry:getComponent(entity, Component.Test3))
+						expect(test4).to.equal(registry:getComponent(entity, Component.Test4))
 						toIterate[entity] = nil
 
 						return test1, test2, test3, test4
@@ -123,7 +125,7 @@ return function()
 				function(context)
 					local registry = context.registry
 					local mapper, toIterate = createTestMapper(registry, {
-						withAll = { "Test1", "Test2" },
+						withAll = { Component.Test1, Component.Test2 },
 					})
 
 					mapper:map(function(entity)

--- a/lib/src/World/Reactor.spec.lua
+++ b/lib/src/World/Reactor.spec.lua
@@ -5,33 +5,35 @@ return function()
 	local SingleReactor = require(script.Parent.SingleReactor)
 	local T = require(script.Parent.Parent.Core.T)
 
+	local Component = {
+		Test1 = {
+			name = "Test1",
+			type = T.table,
+		},
+		Test2 = {
+			name = "Test2",
+			type = T.table,
+		},
+		Test3 = {
+			name = "Test3",
+			type = T.table,
+		},
+		Test4 = {
+			name = "Test4",
+			type = T.table,
+		},
+		TestTag = {
+			name = "TestTag",
+			type = T.none,
+		},
+	}
+
 	beforeEach(function(context)
 		local registry = Registry.new()
 
-		registry:defineComponent({
-			name = "Test1",
-			type = T.table,
-		})
-
-		registry:defineComponent({
-			name = "Test2",
-			type = T.table,
-		})
-
-		registry:defineComponent({
-			name = "Test3",
-			type = T.table,
-		})
-
-		registry:defineComponent({
-			name = "Test4",
-			type = T.table,
-		})
-
-		registry:defineComponent({
-			name = "TestTag",
-			type = T.none,
-		})
+		for _, definition in pairs(Component) do
+			registry:defineComponent(definition)
+		end
 
 		context.registry = registry
 	end)
@@ -49,20 +51,20 @@ return function()
 			local entity = registry:createEntity()
 
 			if i % 2 == 0 then
-				registry:addComponent(entity, "Test1", {})
-				registry:addComponent(entity, "TestTag")
+				registry:addComponent(entity, Component.Test1, {})
+				registry:addComponent(entity, Component.TestTag)
 			end
 
 			if i % 3 == 0 then
-				registry:addComponent(entity, "Test2", {})
+				registry:addComponent(entity, Component.Test2, {})
 			end
 
 			if i % 4 == 0 then
-				registry:addComponent(entity, "Test3", {})
+				registry:addComponent(entity, Component.Test3, {})
 			end
 
 			if i % 5 == 0 then
-				registry:addComponent(entity, "Test4", {})
+				registry:addComponent(entity, Component.Test4, {})
 			end
 
 			if
@@ -96,7 +98,7 @@ return function()
 			"should create a new Reactor when there is anything more than one required component",
 			function(context)
 				local reactor = Reactor.new(context.registry, {
-					withAll = { "Test1", "Test2" },
+					withAll = { Component.Test1, Component.Test2 },
 				})
 
 				expect(getmetatable(reactor)).to.equal(Reactor)
@@ -113,7 +115,7 @@ return function()
 			"should create a new SingleReactor when there is exactly one required component and nothing else",
 			function(context)
 				local reactor = Reactor.new(context.registry, {
-					withAll = { "Test1" },
+					withAll = { Component.Test1 },
 				})
 
 				expect(getmetatable(reactor)).to.equal(SingleReactor)
@@ -123,21 +125,21 @@ return function()
 		it("should populate _required, _updated, and _forbidden", function(context)
 			local registry = context.registry
 			local reactor = Reactor.new(context.registry, {
-				withAll = { "Test1", "Test2" },
-				withUpdated = { "Test3" },
-				without = { "Test4" },
+				withAll = { Component.Test1, Component.Test2 },
+				withUpdated = { Component.Test3 },
+				without = { Component.Test4 },
 			})
 
-			expect(reactor._required[1]).to.equal(registry._pools.Test1)
-			expect(reactor._required[2]).to.equal(registry._pools.Test2)
-			expect(reactor._updated[1]).to.equal(registry._pools.Test3)
-			expect(reactor._forbidden[1]).to.equal(registry._pools.Test4)
+			expect(reactor._required[1]).to.equal(registry._pools[Component.Test1])
+			expect(reactor._required[2]).to.equal(registry._pools[Component.Test2])
+			expect(reactor._updated[1]).to.equal(registry._pools[Component.Test3])
+			expect(reactor._forbidden[1]).to.equal(registry._pools[Component.Test4])
 		end)
 
 		it("should correctly instantiate the full update bitset", function(context)
 			local reactor = Reactor.new(context.registry, {
-				withAll = { "Test1" },
-				withUpdated = { "Test1", "Test2", "Test3" },
+				withAll = { Component.Test1 },
+				withUpdated = { Component.Test1, Component.Test2, Component.Test3 },
 			})
 
 			expect(reactor._allUpdates).to.equal(bit32.rshift(0xFFFFFFFF, 29))
@@ -151,14 +153,14 @@ return function()
 				function(context)
 					local registry = context.registry
 					local reactor, toIterate = createTestReactor(registry, {
-						withAll = { "Test1", "Test2", "Test3" },
+						withAll = { Component.Test1, Component.Test2, Component.Test3 },
 					})
 
 					reactor:each(function(entity, test1, test2, test3)
 						expect(toIterate[entity]).to.equal(true)
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
-						expect(test3).to.equal(registry:getComponent(entity, "Test3"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
+						expect(test3).to.equal(registry:getComponent(entity, Component.Test3))
 						toIterate[entity] = nil
 					end)
 
@@ -173,8 +175,8 @@ return function()
 				function(context)
 					local registry = context.registry
 					local reactor, toIterate = createTestReactor(registry, {
-						withAll = { "Test1", "Test2" },
-						withAny = { "TestTag", "Test4" },
+						withAll = { Component.Test1, Component.Test2 },
+						withAny = { Component.TestTag, Component.Test4 },
 						without = {},
 					})
 
@@ -182,8 +184,8 @@ return function()
 						expect(toIterate[entity]).to.equal(true)
 						toIterate[entity] = nil
 
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
 						expect(test5).to.equal(nil)
 					end)
 
@@ -198,14 +200,14 @@ return function()
 				function(context)
 					local registry = context.registry
 					local reactor, toIterate = createTestReactor(registry, {
-						withAll = { "Test1", "Test2" },
-						without = { "Test3" },
+						withAll = { Component.Test1, Component.Test2 },
+						without = { Component.Test3 },
 					})
 
 					reactor:each(function(entity, test1, test2)
 						expect(toIterate[entity]).to.equal(true)
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
 						toIterate[entity] = nil
 					end)
 
@@ -220,16 +222,16 @@ return function()
 				function(context)
 					local registry = context.registry
 					local reactor, toIterate = createTestReactor(registry, {
-						withAll = { "Test1" },
-						withUpdated = { "Test2", "Test3" },
-						without = { "Test4" },
+						withAll = { Component.Test1 },
+						withUpdated = { Component.Test2, Component.Test3 },
+						without = { Component.Test4 },
 					})
 
 					reactor:each(function(entity, test1, test2, test3)
 						expect(toIterate[entity]).to.be.ok()
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
-						expect(test3).to.equal(registry:getComponent(entity, "Test3"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
+						expect(test3).to.equal(registry:getComponent(entity, Component.Test3))
 						toIterate[entity] = nil
 					end)
 
@@ -240,12 +242,12 @@ return function()
 			it("should capture updates caused during iteration", function(context)
 				local registry = context.registry
 				local reactor, toIterate = createTestReactor(registry, {
-					withAll = { "Test1" },
-					withUpdated = { "Test2" },
+					withAll = { Component.Test1 },
+					withUpdated = { Component.Test2 },
 				})
 
 				reactor:each(function(entity)
-					toIterate[entity] = registry:replaceComponent(entity, "Test2", {})
+					toIterate[entity] = registry:replaceComponent(entity, Component.Test2, {})
 				end)
 
 				expect(next(toIterate)).to.be.ok()
@@ -269,21 +271,21 @@ return function()
 					local called = false
 					local testEntity = registry:createEntity()
 					local reactor = createTestReactor(registry, {
-						withAll = { "Test1", "Test2", "Test3" },
+						withAll = { Component.Test1, Component.Test2, Component.Test3 },
 					})
 
 					reactor.added:connect(function(entity, test1, test2, test3)
 						called = true
 						expect(entity).to.equal(testEntity)
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
-						expect(test3).to.equal(registry:getComponent(entity, "Test3"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
+						expect(test3).to.equal(registry:getComponent(entity, Component.Test3))
 					end)
 
 					registry:withComponents(testEntity, {
-						Test1 = {},
-						Test2 = {},
-						Test3 = {},
+						[Component.Test1] = {},
+						[Component.Test2] = {},
+						[Component.Test3] = {},
 					})
 
 					expect(called).to.equal(true)
@@ -300,27 +302,27 @@ return function()
 					local called = false
 					local testEntity = registry:createEntity()
 					local reactor = createTestReactor(registry, {
-						withAll = { "Test1", "Test2" },
-						without = { "Test3" },
+						withAll = { Component.Test1, Component.Test2 },
+						without = { Component.Test3 },
 					})
 
 					reactor.added:connect(function(entity, test1, test2)
 						called = true
 						expect(entity).to.equal(testEntity)
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
 					end)
 
 					registry:withComponents(testEntity, {
-						Test1 = {},
-						Test2 = {},
+						[Component.Test1] = {},
+						[Component.Test2] = {},
 					})
 
 					expect(called).to.equal(true)
 					expect(reactor._pool:getIndex(testEntity)).to.be.ok()
 
 					called = false
-					registry:addComponent(testEntity, "Test3", {})
+					registry:addComponent(testEntity, Component.Test3, {})
 					expect(called).to.equal(false)
 					expect(reactor._pool:getIndex(testEntity)).to.never.be.ok()
 				end
@@ -335,38 +337,38 @@ return function()
 					local testEntity = registry:createEntity()
 					local called = false
 					local reactor = createTestReactor(registry, {
-						withAll = { "Test1" },
-						withUpdated = { "Test2", "Test4" },
-						without = { "Test3" },
+						withAll = { Component.Test1 },
+						withUpdated = { Component.Test2, Component.Test4 },
+						without = { Component.Test3 },
 					})
 
 					reactor.added:connect(function(entity, test1, test2, test4)
 						called = true
 						expect(entity).to.equal(testEntity)
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
-						expect(test4).to.equal(registry:getComponent(entity, "Test4"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
+						expect(test4).to.equal(registry:getComponent(entity, Component.Test4))
 					end)
 
 					registry:withComponents(testEntity, {
-						Test1 = {},
-						Test2 = {},
-						Test4 = {},
+						[Component.Test1] = {},
+						[Component.Test2] = {},
+						[Component.Test4] = {},
 					})
 
 					expect(called).to.equal(false)
 
-					registry:replaceComponent(testEntity, "Test4", {})
-					registry:replaceComponent(testEntity, "Test2", {})
+					registry:replaceComponent(testEntity, Component.Test4, {})
+					registry:replaceComponent(testEntity, Component.Test2, {})
 					expect(called).to.equal(true)
 					expect(reactor._pool:getIndex(testEntity)).to.be.ok()
 
 					called = false
-					registry:addComponent(testEntity, "Test3", {})
+					registry:addComponent(testEntity, Component.Test3, {})
 					expect(reactor._pool:getIndex(testEntity)).to.never.be.ok()
 
-					registry:replaceComponent(testEntity, "Test4", {})
-					registry:replaceComponent(testEntity, "Test2", {})
+					registry:replaceComponent(testEntity, Component.Test4, {})
+					registry:replaceComponent(testEntity, Component.Test2, {})
 					expect(called).to.equal(false)
 					expect(reactor._pool:getIndex(testEntity)).to.never.be.ok()
 				end
@@ -376,8 +378,8 @@ return function()
 				local registry = context.registry
 				local called = false
 				local reactor = createTestReactor(registry, {
-					withAll = { "Test1", "Test2" },
-					withUpdated = { "Test4" },
+					withAll = { Component.Test1, Component.Test2 },
+					withUpdated = { Component.Test4 },
 				})
 
 				reactor.added:connect(function()
@@ -387,13 +389,13 @@ return function()
 				local testEntity = registry:createEntity()
 
 				registry:withComponents(testEntity, {
-					Test1 = {},
-					Test2 = {},
-					Test4 = {},
+					[Component.Test1] = {},
+					[Component.Test2] = {},
+					[Component.Test4] = {},
 				})
 
-				registry:replaceComponent(testEntity, "Test4", {})
-				registry:replaceComponent(testEntity, "Test4", {})
+				registry:replaceComponent(testEntity, Component.Test4, {})
+				registry:replaceComponent(testEntity, Component.Test4, {})
 				expect(called).to.equal(true)
 			end)
 		end)
@@ -406,24 +408,24 @@ return function()
 					local called = false
 					local testEntity = registry:createEntity()
 					local reactor = createTestReactor(registry, {
-						withAll = { "Test1", "Test2" },
-						withAny = { "Test3", "Test4" },
+						withAll = { Component.Test1, Component.Test2 },
+						withAny = { Component.Test3, Component.Test4 },
 					})
 
 					reactor.added:connect(function(entity, test1, test2, test3, test4)
 						called = true
 						expect(entity).to.equal(testEntity)
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
-						expect(test3).to.equal(registry:getComponent(entity, "Test3"))
-						expect(test4).to.equal(registry:getComponent(entity, "Test4"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
+						expect(test3).to.equal(registry:getComponent(entity, Component.Test3))
+						expect(test4).to.equal(registry:getComponent(entity, Component.Test4))
 					end)
 
 					registry:withComponents(testEntity, {
-						Test1 = {},
-						Test2 = {},
-						Test3 = {},
-						Test4 = {},
+						[Component.Test1] = {},
+						[Component.Test2] = {},
+						[Component.Test3] = {},
+						[Component.Test4] = {},
 					})
 
 					expect(called).to.equal(true)
@@ -442,24 +444,24 @@ return function()
 					local called = false
 					local testEntity = registry:createEntity()
 					local reactor = createTestReactor(registry, {
-						withAll = { "Test1", "Test2", "Test3" },
+						withAll = { Component.Test1, Component.Test2, Component.Test3 },
 					})
 
 					reactor.removed:connect(function(entity, test1, test2, test3)
 						called = true
 						expect(entity).to.equal(testEntity)
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
-						expect(test3).to.equal(registry:getComponent(entity, "Test3"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
+						expect(test3).to.equal(registry:getComponent(entity, Component.Test3))
 					end)
 
 					registry:withComponents(testEntity, {
-						Test1 = {},
-						Test2 = {},
-						Test3 = {},
+						[Component.Test1] = {},
+						[Component.Test2] = {},
+						[Component.Test3] = {},
 					})
 
-					registry:removeComponent(testEntity, "Test2")
+					registry:removeComponent(testEntity, Component.Test2)
 					expect(called).to.equal(true)
 					expect(reactor._pool:getIndex(testEntity)).to.never.be.ok()
 				end
@@ -474,23 +476,23 @@ return function()
 					local called = false
 					local testEntity = registry:createEntity()
 					local reactor = createTestReactor(registry, {
-						withAll = { "Test1", "Test2" },
-						without = { "Test3" },
+						withAll = { Component.Test1, Component.Test2 },
+						without = { Component.Test3 },
 					})
 
 					reactor.removed:connect(function(entity, test1, test2)
 						called = true
 						expect(entity).to.equal(testEntity)
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
 					end)
 
 					registry:withComponents(testEntity, {
-						Test1 = {},
-						Test2 = {},
+						[Component.Test1] = {},
+						[Component.Test2] = {},
 					})
 
-					registry:addComponent(testEntity, "Test3", {})
+					registry:addComponent(testEntity, Component.Test3, {})
 					expect(called).to.equal(true)
 					expect(reactor._pool:getIndex(testEntity)).to.never.be.ok()
 				end
@@ -505,27 +507,27 @@ return function()
 					local called = false
 					local testEntity = registry:createEntity()
 					local reactor = createTestReactor(registry, {
-						withAll = { "Test1", "Test2" },
-						withUpdated = { "Test4" },
-						without = { "Test3" },
+						withAll = { Component.Test1, Component.Test2 },
+						withUpdated = { Component.Test4 },
+						without = { Component.Test3 },
 					})
 
 					reactor.removed:connect(function(entity, test1, test2, test4)
 						called = true
 						expect(entity).to.equal(testEntity)
-						expect(test1).to.equal(registry:getComponent(entity, "Test1"))
-						expect(test2).to.equal(registry:getComponent(entity, "Test2"))
-						expect(test4).to.equal(registry:getComponent(entity, "Test4"))
+						expect(test1).to.equal(registry:getComponent(entity, Component.Test1))
+						expect(test2).to.equal(registry:getComponent(entity, Component.Test2))
+						expect(test4).to.equal(registry:getComponent(entity, Component.Test4))
 					end)
 
 					registry:withComponents(testEntity, {
-						Test1 = {},
-						Test2 = {},
-						Test4 = {},
+						[Component.Test1] = {},
+						[Component.Test2] = {},
+						[Component.Test4] = {},
 					})
 
-					registry:replaceComponent(testEntity, "Test4", {})
-					registry:removeComponent(testEntity, "Test2", {})
+					registry:replaceComponent(testEntity, Component.Test4, {})
+					registry:removeComponent(testEntity, Component.Test2, {})
 					expect(reactor._pool:getIndex(testEntity)).to.never.be.ok()
 					expect(called).to.equal(true)
 				end
@@ -538,19 +540,19 @@ return function()
 				local registry = context.registry
 				local testEntity = registry:createEntity()
 				local reactor = createTestReactor(registry, {
-					withAll = { "Test1", "Test2" },
-					withUpdated = { "Test4" },
-					without = { "Test3" },
+					withAll = { Component.Test1, Component.Test2 },
+					withUpdated = { Component.Test4 },
+					without = { Component.Test3 },
 				})
 
 				registry:withComponents(testEntity, {
-					Test1 = {},
-					Test2 = {},
-					Test4 = {},
+					[Component.Test1] = {},
+					[Component.Test2] = {},
+					[Component.Test4] = {},
 				})
 
-				registry:replaceComponent(testEntity, "Test4", {})
-				registry:removeComponent(testEntity, "Test4")
+				registry:replaceComponent(testEntity, Component.Test4, {})
+				registry:removeComponent(testEntity, Component.Test4)
 				expect(reactor._pool:getIndex(testEntity)).to.never.be.ok()
 				expect(reactor._updates[testEntity]).to.equal(nil)
 			end
@@ -564,7 +566,7 @@ return function()
 			local numCalled = 0
 			local holes = {}
 			local reactor, _, len = createTestReactor(registry, {
-				withAll = { "Test1", "Test2" },
+				withAll = { Component.Test1, Component.Test2 },
 			}, function()
 				local hole = Instance.new("Hole")
 
@@ -584,7 +586,7 @@ return function()
 			numCalled = 0
 
 			reactor:each(function(entity)
-				registry:removeComponent(entity, "Test2")
+				registry:removeComponent(entity, Component.Test2)
 			end)
 
 			event:Fire()
@@ -604,7 +606,7 @@ return function()
 			local event = Instance.new("BindableEvent")
 			local numCalled = 0
 			local reactor = createTestReactor(registry, {
-				withAll = { "Test1", "Test2" },
+				withAll = { Component.Test1, Component.Test2 },
 			}, function()
 				return {
 					event.Event:Connect(function()
@@ -625,7 +627,7 @@ return function()
 			"should remove each entity from the pool and clear their update states",
 			function(context)
 				local reactor, toIterate = createTestReactor(context.registry, {
-					withUpdated = { "Test1" },
+					withUpdated = { Component.Test1 },
 				})
 
 				reactor:consumeEach(function(entity)
@@ -644,16 +646,16 @@ return function()
 		it("should remove the entity from the pool and clear its update state", function(context)
 			local registry = context.registry
 			local reactor = createTestReactor(registry, {
-				withAll = { "Test1" },
-				withUpdated = { "Test2" },
+				withAll = { Component.Test1 },
+				withUpdated = { Component.Test2 },
 			})
 
 			local entity = registry:withComponents(registry:createEntity(), {
-				Test1 = {},
-				Test2 = {},
+				[Component.Test1] = {},
+				[Component.Test2] = {},
 			})
 
-			registry:replaceComponent(entity, "Test2", {})
+			registry:replaceComponent(entity, Component.Test2, {})
 			reactor:consume(entity)
 
 			expect(reactor._pool:get(entity)).to.equal(nil)
@@ -667,23 +669,35 @@ return function()
 			function(context)
 				local registry = context.registry
 				local reactor = createTestReactor(registry, {
-					withAll = { "Test2", "Test3" },
-					withUpdated = { "Test3", "Test4" },
+					withAll = { Component.Test2, Component.Test3 },
+					withUpdated = { Component.Test3, Component.Test4 },
 				})
 
 				local entity = context.registry:withComponents(context.registry:createEntity(), {
-					Test1 = {},
-					Test2 = {},
-					Test3 = {},
-					Test4 = {},
+					[Component.Test1] = {},
+					[Component.Test2] = {},
+					[Component.Test3] = {},
+					[Component.Test4] = {},
 				})
 
 				reactor:_pack(entity)
 
-				expect(reactor._packed[1]).to.equal(context.registry:getComponent(entity, "Test2"))
-				expect(reactor._packed[2]).to.equal(context.registry:getComponent(entity, "Test3"))
-				expect(reactor._packed[3]).to.equal(context.registry:getComponent(entity, "Test3"))
-				expect(reactor._packed[4]).to.equal(context.registry:getComponent(entity, "Test4"))
+				expect(reactor._packed[1]).to.equal(context.registry:getComponent(
+					entity,
+					Component.Test2
+				))
+				expect(reactor._packed[2]).to.equal(context.registry:getComponent(
+					entity,
+					Component.Test3
+				))
+				expect(reactor._packed[3]).to.equal(context.registry:getComponent(
+					entity,
+					Component.Test3
+				))
+				expect(reactor._packed[4]).to.equal(context.registry:getComponent(
+					entity,
+					Component.Test4
+				))
 			end
 		)
 	end)
@@ -694,28 +708,28 @@ return function()
 			function(context)
 				local registry = context.registry
 				local reactor = createTestReactor(registry, {
-					withAll = { "Test1", "Test2" },
-					withAny = { "Test4" },
-					without = { "Test3" },
+					withAll = { Component.Test1, Component.Test2 },
+					withAny = { Component.Test4 },
+					without = { Component.Test3 },
 				})
 
 				local entity = registry:withComponents(registry:createEntity(), {
-					Test1 = {},
-					Test2 = {},
-					Test4 = {},
+					[Component.Test1] = {},
+					[Component.Test2] = {},
+					[Component.Test4] = {},
 				})
 
 				expect(reactor:_tryPack(entity)).to.equal(true)
 
-				expect(reactor._packed[1]).to.equal(registry:getComponent(entity, "Test1"))
-				expect(reactor._packed[2]).to.equal(registry:getComponent(entity, "Test2"))
-				expect(reactor._packed[3]).to.equal(registry:getComponent(entity, "Test4"))
+				expect(reactor._packed[1]).to.equal(registry:getComponent(entity, Component.Test1))
+				expect(reactor._packed[2]).to.equal(registry:getComponent(entity, Component.Test2))
+				expect(reactor._packed[3]).to.equal(registry:getComponent(entity, Component.Test4))
 
 				expect(reactor:_tryPack(registry:withComponents(registry:createEntity(), {
-					Test1 = {},
-					Test2 = {},
-					Test3 = {},
-					Test4 = {},
+					[Component.Test1] = {},
+					[Component.Test2] = {},
+					[Component.Test3] = {},
+					[Component.Test4] = {},
 				}))).to.equal(false)
 			end
 		)

--- a/lib/src/World/Registry.lua
+++ b/lib/src/World/Registry.lua
@@ -506,7 +506,7 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 
 	@param entity number
 	@param ... ComponentDefinition
@@ -536,7 +536,7 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 
 	@param entity number
 	@param ... ComponentDefinition
@@ -565,10 +565,10 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 
 	@param entity number
-	@param definition
+	@param definition ComponentDefinition
 	@return any
 ]=]
 function Registry:getComponent(entity, definition)
@@ -587,11 +587,11 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 
 	@param entity number
 	@param output table
-	@param ...definitions ComponentDefinition
+	@param ... ComponentDefinition
 	@return ...any
 ]=]
 function Registry:getComponents(entity, output, ...)
@@ -610,7 +610,7 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 	@error "entity %d already has a %s" -- The entity already has that component.
 	@error Failed type check -- The given component has the wrong type.
 
@@ -640,7 +640,7 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 	@error "entity %d already has a %s" -- The entity already has that component.
 	@error Failed type check -- The given component has the wrong type.
 
@@ -662,7 +662,7 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 	@error Failed type check -- The given component has the wrong type.
 
 	@param entity number
@@ -694,7 +694,7 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 	@error Failed type check -- The given component has the wrong type.
 
 	@param entity number
@@ -727,7 +727,7 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 	@error Failed type check -- The given component has the wrong type.
 	@error "entity %d does not have a %s" -- The entity is expected to have this component.
 
@@ -759,7 +759,7 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 	@error Failed type check -- The given component has the wrong type.
 
 	@param entity number
@@ -795,7 +795,7 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 	@error "entity %d does not have a %s" -- The entity is expected to have this component.
 
 	@param entity number
@@ -821,7 +821,7 @@ end
 
 	@error "entity must be a number (got %s)" -- The entity is not a number.
 	@error "entity %d does not exist or has been destroyed" -- The entity is invalid.
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 
 	@param entity number
 	@param definition ComponentDefinition
@@ -863,7 +863,7 @@ end
 --[=[
 	Returns the total number of entities with the given component.
 
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 
 	@param definition ComponentDefinition
 	@return number
@@ -912,7 +912,7 @@ end
 	Returns a list of pools containing the specified components in the same order as
 	the given list of component names.
 
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 
 	@private
 	@param definitions {string}
@@ -937,10 +937,10 @@ end
 --[=[
 	Returns the pool containing the specified components.
 
-	@error "invalid component name: %s" -- No component goes by that name.
+	@error 'the component type "%s" is not defined for this registry' -- No component matches that definition.
 
 	@private
-	@param definition string
+	@param definition ComponentDefinition
 	@return Pool
 ]=]
 function Registry:getPool(definition)

--- a/lib/src/World/init.lua
+++ b/lib/src/World/init.lua
@@ -59,6 +59,23 @@ local World = {}
 World.__index = World
 
 --[=[
+	@prop components {[string]: ComponentDefinition}
+	@within World
+
+	A dictionary mapping component names to component definitions. Intended to be used for importing
+	component definitions as follows:
+	```lua
+	-- Assuming we've already defined the World elsewhere with a component called "Money"
+	local world = Anatta:getWorld("MyCoolWorld")
+	local registry = world.registry
+
+	local Money = world.components.Money
+
+	registry:addComponent(registry:create(), Money, 5000)
+	```
+]=]
+
+--[=[
 	Creates a new `World` containing an empty [`Registry`](/api/Registry) and calls
 	[`Registry:defineComponent`](/api/Registry#defineComponent) for each
 	[`ComponentDefinition`](/api/Anatta#ComponentDefinition) in the given list.
@@ -70,15 +87,15 @@ World.__index = World
 function World.new(definitions)
 	local registry = Registry.new()
 
-	local component = {}
+	local components = {}
 
 	for _, definition in ipairs(definitions) do
 		registry:defineComponent(definition)
-		component[definition.name] = definition
+		components[definition.name] = definition
 	end
 
 	return setmetatable({
-		component = component,
+		components = components,
 		registry = registry,
 		_reactorSystems = {},
 	}, World)

--- a/lib/src/World/init.lua
+++ b/lib/src/World/init.lua
@@ -15,10 +15,10 @@
 --[=[
 	@interface Query
 	@within World
-	.withAll {string}?
-	.withUpdated {string}?
-	.withAny {string}?
-	.without {string}?
+	.withAll {ComponentDefinition}?
+	.withUpdated {ComponentDefinition}?
+	.withAny {ComponentDefinition}?
+	.without {ComponentDefinition}?
 
 	A `Query` represents a set of entities to retrieve from a
 	[`Registry`](/api/Registry). A `Query` can be finalized by passing it to
@@ -64,17 +64,21 @@ World.__index = World
 	[`ComponentDefinition`](/api/Anatta#ComponentDefinition) in the given list.
 
 	@ignore
-	@param componentDefinitions {ComponentDefinition}
+	@param definitions {ComponentDefinition}
 	@return World
 ]=]
-function World.new(componentDefinitions)
+function World.new(definitions)
 	local registry = Registry.new()
 
-	for _, componentDefinition in ipairs(componentDefinitions) do
-		registry:defineComponent(componentDefinition)
+	local component = {}
+
+	for _, definition in ipairs(definitions) do
+		registry:defineComponent(definition)
+		component[definition.name] = definition
 	end
 
 	return setmetatable({
+		component = component,
 		registry = registry,
 		_reactorSystems = {},
 	}, World)

--- a/lib/src/init.lua
+++ b/lib/src/init.lua
@@ -34,7 +34,7 @@ local Worlds = {}
 	@function createWorld
 	@within Anatta
 	@param namespace string
-	@param componentDefinitions {[string]: ComponentDefinition} | Instance
+	@param componentDefinitions {ComponentDefinition} | Instance
 	@return World
 ]=]
 local function createWorld(namespace, componentDefinitions)

--- a/lib/src/init.lua
+++ b/lib/src/init.lua
@@ -34,29 +34,36 @@ local Worlds = {}
 	@function createWorld
 	@within Anatta
 	@param namespace string
-	@param componentDefinitions {ComponentDefinition | Instance}
+	@param componentDefinitions {[string]: ComponentDefinition} | Instance
 	@return World
 ]=]
 local function createWorld(namespace, componentDefinitions)
-	util.jumpAssert(not Worlds[namespace], ErrWorldAlreadyExists:format(namespace))
+	local definitions = {}
+
+	util.jumpAssert(not Worlds[namespace], ErrWorldAlreadyExists, namespace)
 
 	if typeof(componentDefinitions) == "table" then
-		util.jumpAssert(Types.ComponentDefinition)
+		for _, definition in pairs(componentDefinitions) do
+			util.jumpAssert(Types.ComponentDefinition(definition))
+			table.insert(definitions, definition)
+		end
 	elseif typeof(componentDefinitions) == "Instance" then
+		local instance = componentDefinitions
+
 		componentDefinitions = {}
 
-		for _, instance in ipairs(componentDefinitions:GetDescendants()) do
-			if instance:IsA("ModuleScript") and not instance.Name:find("%.spec$") then
-				local componentDefinition = require(instance)
+		for _, descendant in ipairs(instance:GetDescendants()) do
+			if descendant:IsA("ModuleScript") and not descendant.Name:find("%.spec$") then
+				local definition = require(descendant)
 
-				if Types.ComponentType(componentDefinition) then
-					table.insert(componentDefinitions, componentDefinition)
+				if Types.ComponentType(definition) then
+					table.insert(definitions, definition)
 				end
 			end
 		end
 	end
 
-	local world = World.new(componentDefinitions or {})
+	local world = World.new(definitions)
 	Worlds[namespace] = world
 
 	return world
@@ -73,7 +80,7 @@ end
 local function getWorld(namespace, script)
 	local world = Worlds[namespace]
 
-	util.jumpAssert(world, ErrWorldDoesntExist:format(namespace))
+	util.jumpAssert(world, ErrWorldDoesntExist, namespace)
 
 	if script then
 		world:addSystem(script)

--- a/lib/src/init.spec.lua
+++ b/lib/src/init.spec.lua
@@ -4,19 +4,21 @@ return function()
 
 	describe("createWorld", function()
 		it("should define a list of ComponentDefinitions for the world's registry", function()
-			local world = Anatta.createWorld("TestWorld1", {
-				{
+			local Component = {
+				Loooooooook = {
 					name = "Loooooooook",
 					type = T.table,
 				},
-				{
+				Heeeeeeerree = {
 					name = "Heeeeeeerree",
 					type = T.table,
 				},
-			})
+			}
 
-			expect(world.registry:isComponentDefined("Loooooooook")).to.equal(true)
-			expect(world.registry:isComponentDefined("Heeeeeeerree")).to.equal(true)
+			local world = Anatta.createWorld("TestWorld1", Component)
+
+			expect(world.registry:isComponentDefined(Component.Loooooooook)).to.equal(true)
+			expect(world.registry:isComponentDefined(Component.Heeeeeeerree)).to.equal(true)
 		end)
 	end)
 

--- a/lib/src/util/jumpAssert.lua
+++ b/lib/src/util/jumpAssert.lua
@@ -1,5 +1,11 @@
-return function(condition, errorMessage)
+return function(condition, errorMessage, ...)
 	if not condition then
-		error(errorMessage, 3)
+		local params = table.pack(...)
+
+		for i, param in pairs(params) do
+			params[i] = tostring(param)
+		end
+
+		error(errorMessage:format(unpack(params)), 3)
 	end
 end


### PR DESCRIPTION
This PR changes all the methods that accepted a string component name in favor of taking a `ComponentDefinition` directly. It also adds the property `World.components`, which can be used to import a component that's been defined for a `World`.