### PR TITLE
Make `Dom` attribute conversions handle the entity attribute

### DIFF
--- a/lib/src/Dom/init.lua
+++ b/lib/src/Dom/init.lua
@@ -63,7 +63,7 @@ local tryFromTagged = require(script.tryFromTagged)
 	@param instance Instance
 	@param component any
 	@param componentDefinition ComponentDefinition
-	@return boolean, number, {[string]: any]}
+	@return boolean, {[string]: any]}
 
 	Takes an entity, a component on the entity, and the component's
 	[`ComponentDefinition`](/api/Anatta#ComponentDefinition) and attempts to convert the

--- a/lib/src/Dom/init.lua
+++ b/lib/src/Dom/init.lua
@@ -31,11 +31,14 @@ local tryFromDom = require(script.tryFromDom)
 	@within Dom
 	@param instance Instance
 	@param componentDefinition ComponentDefinition
-	@return boolean, any
+	@return boolean, number, any
 
-	Attempts to convert the attributes of a given `Instance` into a component of the given
-	[`ComponentDefinition`](/api/Anatta#ComponentDefinition). Returns a success value followed
-	by the converted component (if successful) or an error message (if unsuccessful).
+	Attempts to convert the attributes of a given `Instance` into an entity and a
+	component of the given
+	[`ComponentDefinition`](/api/Anatta#ComponentDefinition). Returns a success value
+	followed by the entity and the converted component (if successful) or an error message
+	(if unsuccessful).
+
 ]=]
 local tryFromAttributes = require(script.tryFromAttributes)
 
@@ -60,13 +63,13 @@ local tryFromTagged = require(script.tryFromTagged)
 	@param instance Instance
 	@param component any
 	@param componentDefinition ComponentDefinition
-	@return boolean, {[string]: any]}
+	@return boolean, number, {[string]: any]}
 
-	Takes a component and the component's
+	Takes an entity, a component on the entity, and the component's
 	[`ComponentDefinition`](/api/Anatta#ComponentDefinition) and attempts to convert the
 	component into a dictionary that can be used to set attributes on an `Instance`. The
 	keys of the returned dictionary are the names of the requested attributes, while the
-	values correspond to the value of the component.
+	values correspond to the entity and the value(s) of the component.
 
 	Returns a success value followed by the attribute dictionary (if successful) or an
 	error message (if unsuccessful).
@@ -81,6 +84,7 @@ local tryToAttributes = require(script.tryToAttributes)
 --[=[
 	@function waitForRefs
 	@within Dom
+	@private
 	@yields
 ]=]
 local waitForRefs = require(script.waitForRefs)

--- a/lib/src/Dom/tryFromAttributes.spec.lua
+++ b/lib/src/Dom/tryFromAttributes.spec.lua
@@ -2,7 +2,6 @@ return function()
 	local Constants = require(script.Parent.Parent.Core.Constants)
 	local T = require(script.Parent.Parent.Core.T)
 
-	FOCUS()
 	local ENTITY_ATTRIBUTE_NAME = Constants.EntityAttributeName
 	local INSTANCE_REF_FOLDER = Constants.InstanceRefFolder
 

--- a/lib/src/Dom/tryFromTagged.lua
+++ b/lib/src/Dom/tryFromTagged.lua
@@ -1,11 +1,8 @@
 local CollectionService = game:GetService("CollectionService")
 
-local Constants = require(script.Parent.Parent.Core.Constants)
 local util = require(script.Parent.Parent.util)
 
 local tryFromAttributes = require(script.Parent.tryFromAttributes)
-
-local ENTITY_ATTRIBUTE_NAME = Constants.EntityAttributeName
 
 return function(pool)
 	util.jumpAssert(pool.size == 0, "Pool must be empty")
@@ -19,27 +16,17 @@ return function(pool)
 	pool.components = table.create(taggedCount)
 
 	for _, instance in ipairs(tagged) do
-		local entity = instance:GetAttribute(ENTITY_ATTRIBUTE_NAME)
+		local success, component, entity =
+			tryFromAttributes(instance, componentName, typeDefinition)
 
-		if entity == nil or typeof(entity) ~= "number" then
-			warn(("Instance %s did not have a valid entity attribute"):format(instance:GetFullName()))
-			continue
-		end
-
-		local componentSuccess, componentResult = tryFromAttributes(
-			instance,
-			componentName,
-			typeDefinition
-		)
-
-		if not componentSuccess then
-			warn(("Instance %s failed attribute validation for %s"):format(
+		if not success then
+			warn(("%s failed attribute validation for %s"):format(
 				instance:GetFullName(),
 				componentName
 			))
 		end
 
-		pool:insert(entity, componentResult)
+		pool:insert(entity, component)
 	end
 
 	return true, pool

--- a/lib/src/Dom/tryToAttributes.lua
+++ b/lib/src/Dom/tryToAttributes.lua
@@ -1,6 +1,7 @@
 local Constants = require(script.Parent.Parent.Core.Constants)
 local util = require(script.Parent.Parent.util)
 
+local ENTITY_ATTRIBUTE_NAME = Constants.EntityAttributeName
 local INSTANCE_REF_FOLDER = Constants.InstanceRefFolder
 
 local ErrConversionFailed = "%s (%s) cannot be turned into an attribute"
@@ -48,7 +49,7 @@ local conversions = {
 	end,
 }
 
-function convert(attributeMap, attributeName, concreteType, value, instance)
+function convert(attributeMap, attributeName, concreteType, instance, entity, value)
 	if typeof(concreteType) == "table" then
 		for field, fieldConcreteType in pairs(concreteType) do
 			local fieldAttributeName = ("%s_%s"):format(attributeName, field)
@@ -63,10 +64,12 @@ function convert(attributeMap, attributeName, concreteType, value, instance)
 		return false, (ErrConversionFailed:format(attributeName, concreteType))
 	end
 
+	attributeMap[ENTITY_ATTRIBUTE_NAME] = entity
+
 	return true, attributeMap
 end
 
-return function(instance, component, componentDefinition)
+return function(instance, entity, component, componentDefinition)
 	local typeDefinition = componentDefinition.type
 	local componentName = componentDefinition.name
 
@@ -78,5 +81,5 @@ return function(instance, component, componentDefinition)
 		return false, ("Error converting %s: %s"):format(componentName, concreteType)
 	end
 
-	return convert({}, componentName, concreteType, component, instance)
+	return convert({}, componentName, concreteType, instance, entity, component)
 end

--- a/lib/src/World/Mapper.lua
+++ b/lib/src/World/Mapper.lua
@@ -40,7 +40,7 @@ function Mapper.new(registry, query)
 end
 
 --[=[
-	@param callback (number, ...any) -> ...any
+	@param callback (entity: number, ...any) -> ...any
 
 	Maps over entities that satisfy the `Query`. Calls the callback for each entity,
 	passing each entity followed by the components specified by the `Query` and replacing
@@ -59,7 +59,7 @@ function Mapper:map(callback)
 end
 
 --[=[
-	@param callback (number, ...any)
+	@param callback (entity: number, ...any) -> ()
 
 	Iterates over all entities that satisfy the `Query`. Calls the callback for each
 	entity, passing each entity followed by the components specified by the `Query`.

--- a/lib/src/World/Reactor.lua
+++ b/lib/src/World/Reactor.lua
@@ -87,7 +87,7 @@ function Reactor.new(registry, query)
 end
 
 --[=[
-	@param callback (number, ...any) -> {RBXScriptConnection | Instance}
+	@param callback (entity: number, ...any) -> {RBXScriptConnection | Instance}
 
 	Calls the callback every time an entity enters the `Reactor`, passing each entity and
 	its components and attaching the return value to each entity.  The callback should
@@ -129,7 +129,7 @@ function Reactor:detach()
 end
 
 --[=[
-	@param callback (number, ...any)
+	@param callback (entity: number, ...any) -> ()
 
 	Iterates over the all the entities present in the `Reactor`. Calls the callback for
 	each entity, passing each entity followed by the components provided in the
@@ -149,7 +149,7 @@ function Reactor:each(callback)
 end
 
 --[=[
-	@param callback (number, ...any)
+	@param callback (entity: number, ...any) -> ()
 
 	Iterates over all the entities present in the `Reactor` and clears each entity's
 	update status. Calls the callback for each entity visited during the iteration,

--- a/lib/src/World/Registry.lua
+++ b/lib/src/World/Registry.lua
@@ -882,7 +882,7 @@ end
 --[=[
 	Passes each entity currently in use by the registry to the given callback.
 
-	@param callback (entity: number)
+	@param callback (entity: number) -> ()
 ]=]
 function Registry:each(callback)
 	if self._nextRecyclableEntityId == NULL_ENTITYID then


### PR DESCRIPTION
It was an oversight that `Dom.tryFromAttributes` and `Dom.tryToAttributes` did not consider the entity attribute. This PR fixes that.