### PR TITLE
Make ComponentDefinition a t.interface

### DIFF
--- a/lib/src/Types.lua
+++ b/lib/src/Types.lua
@@ -6,7 +6,7 @@ local TypeDefinition = t.strictInterface({
 	typeName = t.string,
 })
 
-local ComponentDefinition = t.strictInterface({
+local ComponentDefinition = t.interface({
 	description = t.optional(t.string),
 	name = t.string,
 	type = TypeDefinition,


### PR DESCRIPTION
This allows consumers to extend component definitions with any additional metadata they might need