### PR TITLE
Skip instance after failed attribute validation in Dom.tryFromTagged

### DIFF
--- a/lib/src/Dom/tryFromTagged.lua
+++ b/lib/src/Dom/tryFromTagged.lua
@@ -24,6 +24,7 @@ return function(pool)
 				instance:GetFullName(),
 				componentName
 			))
+			continue
 		end
 
 		pool:insert(entity, component)


### PR DESCRIPTION
Small oversight - this makes its behavior actually match the documention (also applies for `Dom.tryFromDom`, because it uses `Dom.tryFromTagged`)