### PR TITLE
Fire updated signal after replacing the component

### DIFF
--- a/lib/src/Dom/tryFromTagged.lua
+++ b/lib/src/Dom/tryFromTagged.lua
@@ -24,6 +24,7 @@ return function(pool)
 				instance:GetFullName(),
 				componentName
 			))
+			continue
 		end
 
 		pool:insert(entity, component)

--- a/lib/src/World/Registry.lua
+++ b/lib/src/World/Registry.lua
@@ -745,8 +745,8 @@ function Registry:replaceComponent(entity, definition, component)
 		jumpAssert(pool:getIndex(entity), ErrMissingComponent, entity, definition)
 	end
 
-	pool.updated:dispatch(entity, component)
 	pool:replace(entity, component)
+	pool.updated:dispatch(entity, component)
 
 	return component
 end

--- a/lib/src/World/Registry.lua
+++ b/lib/src/World/Registry.lua
@@ -778,8 +778,8 @@ function Registry:addOrReplaceComponent(entity, definition, component)
 	local denseIndex = pool:getIndex(entity)
 
 	if denseIndex then
-		pool.updated:dispatch(entity, component)
 		pool:replace(entity, component)
+		pool.updated:dispatch(entity, component)
 		return component
 	end
 

--- a/lib/src/World/Registry.spec.lua
+++ b/lib/src/World/Registry.spec.lua
@@ -260,8 +260,10 @@ return function()
 			expect(registry:entityIsValid(NULL_ENTITYID)).to.equal(false)
 		end)
 
-		it("should return false if the entity is not a number", function(context)
-			expect(context.registry:entityIsValid("entity")).to.equal(false)
+		it("should error if the entity is not a number", function(context)
+			expect(function()
+				context.registry:entityIsValid("entity")
+			end).to.throw()
 		end)
 	end)
 


### PR DESCRIPTION
This fixes an issue where a reactor watching updates to components would be passed the old component instead of the new one