### PR TITLE
Fire the removed signal in `Reactor:consume`

### DIFF
--- a/lib/src/World/Reactor.lua
+++ b/lib/src/World/Reactor.lua
@@ -211,6 +211,8 @@ function Reactor:consume(entity)
 
 	self._pool:delete(entity)
 	self._updates[entity] = nil
+	self:_pack(entity)
+	self.removed:dispatch(entity, unpack(self._packed, 1, self._numPacked))
 end
 
 --[[


### PR DESCRIPTION
This fixes an issue where instaces/connections returned from
withAttachments would not be cleaned up after an entity left the
reactor because of a consume call