### PR TITLE
Make T error when indexed with an invalid type name

### DIFF
--- a/lib/src/Core/T.lua
+++ b/lib/src/Core/T.lua
@@ -310,14 +310,22 @@ function TypeDefinition:tryGetConcreteType()
 	end
 end
 
+local T = setmetatable({}, {
+	__index = function(self, typeName)
+		if rawget(self, typeName) == nil then
+			error(("%s is not a valid type name"):format(typeName), 3)
+		end
+	end,
+})
+
 for typeName in pairs(t) do
 	if firstOrder[typeName] ~= nil then
-		TypeDefinition[typeName] = TypeDefinition._new(typeName, t[typeName])
+		T[typeName] = TypeDefinition._new(typeName, t[typeName])
 	elseif secondOrder[typeName] ~= nil then
-		TypeDefinition[typeName] = function(...)
+		T[typeName] = function(...)
 			return TypeDefinition._new(typeName, t[typeName](unwrap(...)), ...)
 		end
 	end
 end
 
-return TypeDefinition
+return T

--- a/lib/src/Core/T.spec.lua
+++ b/lib/src/Core/T.spec.lua
@@ -91,4 +91,12 @@ return function()
 			expect(concreteType).to.equal("string")
 		end)
 	end)
+
+	describe("API", function()
+		it("should throw when indexed with an invalid type name", function()
+			expect(function()
+				T.instanceof("Part")
+			end).to.throw()
+		end)
+	end)
 end


### PR DESCRIPTION
Closes #102 

This improves the user experience by providing an error message when, e.g. a typo is made in a type name