### PR TITLE
Add `Reactor:getAttachment`, use pairs to iterate attachments

### DIFF
--- a/lib/src/World/Reactor.lua
+++ b/lib/src/World/Reactor.lua
@@ -116,13 +116,18 @@ function Reactor:withAttachments(callback)
 	end)
 
 	local attachmentsRemoved = self.removed:connect(function(entity)
-		for _, item in ipairs(self._pool:get(entity)) do
+		for _, item in pairs(self._pool:get(entity)) do
 			Finalizers[typeof(item)](item)
 		end
 	end)
 
 	table.insert(self._connections, attachmentsAdded)
 	table.insert(self._connections, attachmentsRemoved)
+end
+
+function Reactor:getAttachment(entity)
+	util.jumpAssert(self._pool:getIndex(entity) ~= nil, ErrEntityMissing, entity)
+	return self._pool:get(entity)
 end
 
 --[=[


### PR DESCRIPTION
I think it's time to allow attachments to be accessed via a `Reactor`. This PR adds `Reactor:getAttachment` lets the return table from a `Reactor:withAttachments` callback be a dictionary to facilitate this.