### PR TITLE
Make withAttachments always insert a table into Reactor pool

### DIFF
--- a/lib/src/World/Reactor.lua
+++ b/lib/src/World/Reactor.lua
@@ -112,7 +112,8 @@ end
 ]=]
 function Reactor:withAttachments(callback)
 	local attachmentsAdded = self.added:connect(function(entity, ...)
-		self._pool:replace(entity, callback(entity, ...))
+		local result = callback(entity, ...)
+		self._pool:replace(entity, typeof(result) == "table" and result or {})
 	end)
 
 	local attachmentsRemoved = self.removed:connect(function(entity)


### PR DESCRIPTION
This PR makes `Reactor:withAttachments` always insert a table into `Reactor._pool`. This prevents hard errors when a consumer returns something other than a table from the callback