### PR TITLE
Early out from `Dom.waitForRefs` when a type contains no refs

### DIFF
--- a/lib/src/Core/T.lua
+++ b/lib/src/Core/T.lua
@@ -108,31 +108,12 @@ local unserializable = {
 	table = true,
 }
 
+local function makeConcreteInstance(typeDefinition)
+	typeDefinition._containsRefs = true
+	return true, "Instance"
+end
+
 local concreters = {
-	union = function(typeDefinition)
-		local success, previousConcreteType = typeDefinition.typeParams[1]:tryGetConcreteType()
-
-		if not success then
-			return false, previousConcreteType
-		end
-
-		for _, typeParam in ipairs(typeDefinition.typeParams) do
-			local currentConcreteType
-			success, currentConcreteType = typeParam:tryGetConcreteType()
-
-			if not success then
-				return false, currentConcreteType
-			end
-
-			if (currentConcreteType == nil) or (currentConcreteType ~= previousConcreteType) then
-				return false, nil
-			else
-				previousConcreteType = currentConcreteType
-			end
-		end
-
-		return true, previousConcreteType
-	end,
 
 	literal = function(typeDefinition)
 		return true, typeof(typeDefinition.typeParams[1])
@@ -168,6 +149,31 @@ local concreters = {
 		end
 
 		return true, result
+	end,
+
+	union = function(typeDefinition)
+		local success, previousConcreteType = typeDefinition.typeParams[1]:tryGetConcreteType()
+
+		if not success then
+			return false, previousConcreteType
+		end
+
+		for _, typeParam in ipairs(typeDefinition.typeParams) do
+			local currentConcreteType
+			success, currentConcreteType = typeParam:tryGetConcreteType()
+
+			if not success then
+				return false, currentConcreteType
+			end
+
+			if (currentConcreteType == nil) or (currentConcreteType ~= previousConcreteType) then
+				return false, nil
+			else
+				previousConcreteType = currentConcreteType
+			end
+		end
+
+		return true, previousConcreteType
 	end,
 }
 
@@ -251,11 +257,13 @@ local defaults = {
 		ColorSequenceKeypoint.new(0, Color3.new()),
 		ColorSequenceKeypoint.new(1, Color3.new()),
 	}),
+
 	NumberRange = NumberRange.new(0, 0),
 	NumberSequence = NumberSequence.new({
 		NumberSequenceKeypoint.new(0, 0),
 		NumberSequenceKeypoint.new(1, 0),
 	}),
+
 	Rect = Rect.new(Vector2.new(), Vector2.new()),
 	TweenInfo = TweenInfo.new(),
 	UDim = UDim.new(0, 0),

--- a/lib/src/Core/T.lua
+++ b/lib/src/Core/T.lua
@@ -212,8 +212,8 @@ local defaults = {
 		return true, default
 	end,
 
-	Instance = function(typeDefinition)
-		return true, Instance.new("Hole")
+	Instance = function()
+		return true, Instance.new("Folder")
 	end,
 
 	instanceOf = function(typeDefinition)

--- a/lib/src/Dom/waitForRefs.lua
+++ b/lib/src/Dom/waitForRefs.lua
@@ -5,6 +5,10 @@ local INSTANCE_REF_FOLDER = Constants.InstanceRefFolder
 local function waitForRefs(instance, attributeName, typeDefinition, objectValues, refFolder)
 	local _, concreteType = typeDefinition:tryGetConcreteType()
 
+	if not typeDefinition._containsRefs then
+		return {}
+	end
+
 	refFolder = refFolder or instance:WaitForChild(INSTANCE_REF_FOLDER)
 
 	objectValues = objectValues or {}

--- a/lib/src/Dom/waitForRefs.spec.lua
+++ b/lib/src/Dom/waitForRefs.spec.lua
@@ -1,0 +1,16 @@
+return function()
+	local T = require(script.Parent.Parent.Core.T)
+	local waitForRefs = require(script.Parent.waitForRefs)
+
+	it("should return an empty table when the type definition contains no refs", function()
+		local ty = T.strictInterface({
+			field1 = T.number,
+			field2 = T.Vector3,
+		})
+
+		local refs = waitForRefs(Instance.new("Folder"), "Test", ty)
+
+		expect(refs).to.be.a("table")
+		expect(next(refs)).to.equal(nil)
+	end)
+end

--- a/lib/src/Types.lua
+++ b/lib/src/Types.lua
@@ -4,6 +4,7 @@ local TypeDefinition = t.strictInterface({
 	typeParams = t.table,
 	check = t.callback,
 	typeName = t.string,
+	_containsRefs = t.boolean,
 })
 
 local ComponentDefinition = t.interface({


### PR DESCRIPTION
This PR addresses problems with using `Dom.waitForRefs` generically. Previously, a consumer had to inspect the type definition themselves to determine whether or not to use `waitForRefs` for a given type, but with this change, they can safely use it without such a check.