### PR TITLE
Add domain field to entity identifiers 

### DIFF
--- a/lib/src/Core/Constants.lua
+++ b/lib/src/Core/Constants.lua
@@ -1,11 +1,17 @@
-local EntityIdWidth = 24
+local EntityIdWidth = 20
+
+local RunService = game:GetService("RunService")
 
 return {
 	Debug = true,
-	EntityIdMask = bit32.rshift(0xFFFFFFFF, 32 - EntityIdWidth),
+	DomainOffset = 31,
 	EntityIdWidth = EntityIdWidth,
+	EntityIdOffset = 0,
 	EntityAttributeName = "__entity",
 	InstanceRefFolder = "__anattaRefs",
-	SharedInstanceTagName = ".anattaSharedInstance",
+	Domain = (RunService:IsServer() or RunService:IsEdit()) and 0 or 1,
 	NullEntityId = 0,
+	SharedInstanceTagName = ".anattaSharedInstance",
+	VersionOffset = EntityIdWidth,
+	VersionWidth = 31 - EntityIdWidth,
 }

--- a/lib/src/Core/Constants.lua
+++ b/lib/src/Core/Constants.lua
@@ -1,17 +1,49 @@
-local EntityIdWidth = 20
+local PartialIdWidth = 23
 
 local RunService = game:GetService("RunService")
 
-return {
+--[[
+	Entity Masking:
+	D = Domain
+	V = Version
+	I = Partial ID
+	P = Pointer
+
+	I+D = Entity ID
+
+	 VERSION   ENTITY ID
+	|-------| |---------------------------|
+	VVVV VVVV IIII IIII IIII IIII IIII IIID
+]]
+
+local Constants = {
 	Debug = true,
-	DomainOffset = 31,
-	EntityIdWidth = EntityIdWidth,
+
+	-- Domain: server = even; client = odd
+	DomainOffset = 0,
+	DomainWidth = 1,
+	Domain = if RunService:IsServer() then 0 else 1,
+
+	-- Partial entity IDs exclude domain
+	PartialIdOffset = 1,
+	PartialIdWidth = PartialIdWidth, -- 23
+
+	-- Entity ID = Partial ID + Domain
 	EntityIdOffset = 0,
+	EntityIdWidth = PartialIdWidth + 1,
+	EntityIdMask = 0x00FFFFFF,
+
+	-- Version increments per entity cycle
+	VersionOffset = PartialIdWidth + 1,
+	VersionWidth = 32 - (PartialIdWidth + 1),
+
+	-- Bookkeeping
+	NullEntityId = 0,
+
+	-- DOM
+	SharedInstanceTagName = ".anattaSharedInstance",
 	EntityAttributeName = "__entity",
 	InstanceRefFolder = "__anattaRefs",
-	Domain = (RunService:IsServer() or RunService:IsEdit()) and 0 or 1,
-	NullEntityId = 0,
-	SharedInstanceTagName = ".anattaSharedInstance",
-	VersionOffset = EntityIdWidth,
-	VersionWidth = 31 - EntityIdWidth,
 }
+
+return Constants

--- a/lib/src/Core/Constants.lua
+++ b/lib/src/Core/Constants.lua
@@ -2,6 +2,9 @@ local PartialIdWidth = 23
 
 local RunService = game:GetService("RunService")
 
+local IsRunning = RunService:IsRunning()
+local IsServer = RunService:IsServer()
+
 --[[
 	Entity Masking:
 	D = Domain
@@ -22,7 +25,8 @@ local Constants = {
 	-- Domain: server = even; client = odd
 	DomainOffset = 0,
 	DomainWidth = 1,
-	Domain = if RunService:IsServer() then 0 else 1,
+
+	Domain = if not IsRunning then 0 elseif IsServer then 0 else 1,
 
 	-- Partial entity IDs exclude domain
 	PartialIdOffset = 1,

--- a/lib/src/Core/Pool.lua
+++ b/lib/src/Core/Pool.lua
@@ -28,11 +28,11 @@ function Pool:getIndex(entity)
 end
 
 function Pool:get(entity)
-	return self.components[self.sparse[bit32.extract(entity, ENTITYID_OFFSET, ENTITYID_WIDTH)]]
+	return self.components[self:getIndex(entity)]
 end
 
 function Pool:replace(entity, component)
-	self.components[self.sparse[bit32.extract(entity, ENTITYID_OFFSET, ENTITYID_WIDTH)]] = component
+	self.components[self:getIndex(entity)] = component
 end
 
 function Pool:insert(entity, component)

--- a/lib/src/Core/Pool.spec.lua
+++ b/lib/src/Core/Pool.spec.lua
@@ -2,16 +2,17 @@ return function()
 	local Constants = require(script.Parent.Constants)
 	local Pool = require(script.Parent.Pool)
 
-	local ENTITYID_MASK = Constants.EntityIdMask
+	local ENTITYID_OFFSET = Constants.EntityIdOffset
 	local ENTITYID_WIDTH = Constants.EntityIdWidth
+	local VERSION_WIDTH = Constants.VersionWidth
 
 	local function generate(pool)
 		local rand = Random.new()
 		local size = 0
 
 		for _ = 1, 200 do
-			local id = rand:NextInteger(1, 2 ^ 16 - 1)
-			local version = bit32.lshift(rand:NextInteger(1, 2 ^ 16 - 1), ENTITYID_WIDTH)
+			local id = rand:NextInteger(1, 2 ^ ENTITYID_WIDTH - 1)
+			local version = bit32.lshift(rand:NextInteger(1, 2 ^ VERSION_WIDTH - 1), ENTITYID_WIDTH)
 
 			if not pool.sparse[id] then
 				size += 1
@@ -64,7 +65,7 @@ return function()
 			expect(pool.size).to.equal(size)
 
 			for i, v in ipairs(pool.dense) do
-				expect(pool.sparse[bit32.band(v, ENTITYID_MASK)]).to.equal(i)
+				expect(pool.sparse[bit32.extract(v, ENTITYID_OFFSET, ENTITYID_WIDTH)]).to.equal(i)
 			end
 		end)
 	end)

--- a/lib/src/World/Registry.lua
+++ b/lib/src/World/Registry.lua
@@ -132,7 +132,7 @@ end
 	@return number
 ]=]
 function Registry.getDomain(entity)
-	return Constants[bit32.extract(entity, DOMAIN_OFFSET, DOMAIN_WIDTH)]
+	return bit32.extract(entity, DOMAIN_OFFSET, DOMAIN_WIDTH)
 end
 
 --[=[

--- a/lib/src/World/Registry.lua
+++ b/lib/src/World/Registry.lua
@@ -472,7 +472,7 @@ end
 	```
 
 	@param entity number
-	@return boolean
+	@return boolean, string, number, string?, string?
 ]=]
 function Registry:entityIsValid(entity)
 	if typeof(entity) ~= "number" then
@@ -482,7 +482,7 @@ function Registry:entityIsValid(entity)
 	local domain = bit32.extract(entity, DOMAIN_OFFSET)
 
 	if domain ~= DOMAIN then
-		return false, ErrWrongDomain:format(WrongDomainName, ExpectedDomainName)
+		return false, ErrWrongDomain, entity, WrongDomainName, ExpectedDomainName
 	end
 
 	if self._entities[bit32.extract(entity, ENTITYID_OFFSET, ENTITYID_WIDTH)] ~= entity then
@@ -517,7 +517,7 @@ end
 ]=]
 function Registry:entityIsOrphaned(entity)
 	if DEBUG then
-		jumpAssert(self:entityIsValid(entity), ErrInvalidEntity, entity)
+		jumpAssert(self:entityIsValid(entity))
 	end
 
 	for _, pool in pairs(self._pools) do
@@ -545,7 +545,7 @@ end
 function Registry:visitComponents(callback, entity)
 	if entity ~= nil then
 		if DEBUG then
-			jumpAssert(self:entityIsValid(entity), ErrInvalidEntity, entity)
+			jumpAssert(self:entityIsValid(entity))
 		end
 
 		for definition, pool in pairs(self._pools) do
@@ -581,7 +581,7 @@ end
 ]=]
 function Registry:entityHas(entity, ...)
 	if DEBUG then
-		jumpAssert(self:entityIsValid(entity), ErrInvalidEntity, entity)
+		jumpAssert(self:entityIsValid(entity))
 
 		for i = 1, select("#", ...) do
 			jumpAssert(self._pools[select(i, ...)], ErrBadComponentDefinition, select(i, ...))
@@ -611,7 +611,7 @@ end
 ]=]
 function Registry:entityHasAny(entity, ...)
 	if DEBUG then
-		jumpAssert(self:entityIsValid(entity), ErrInvalidEntity, entity)
+		jumpAssert(self:entityIsValid(entity))
 
 		for i = 1, select("#", ...) do
 			jumpAssert(self._pools[select(i, ...)], ErrBadComponentDefinition, select(i, ...))
@@ -642,7 +642,7 @@ function Registry:getComponent(entity, definition)
 	local pool = self._pools[definition]
 
 	if DEBUG then
-		jumpAssert(self:entityIsValid(entity), ErrInvalidEntity, entity)
+		jumpAssert(self:entityIsValid(entity))
 		jumpAssert(pool, ErrBadComponentDefinition, definition)
 	end
 
@@ -690,7 +690,7 @@ function Registry:addComponent(entity, definition, component)
 	local pool = self._pools[definition]
 
 	if DEBUG then
-		jumpAssert(self:entityIsValid(entity), ErrInvalidEntity, entity)
+		jumpAssert(self:entityIsValid(entity))
 		jumpAssert(pool, ErrBadComponentDefinition, definition)
 		jumpAssert(not pool:getIndex(entity), ErrAlreadyHasComponent, entity, definition)
 		jumpAssert(pool.typeCheck(component))
@@ -772,7 +772,7 @@ function Registry:getOrAddComponent(entity, definition, component)
 	local pool = self._pools[definition]
 
 	if DEBUG then
-		jumpAssert(self:entityIsValid(entity), ErrInvalidEntity, entity)
+		jumpAssert(self:entityIsValid(entity))
 		jumpAssert(pool, ErrBadComponentDefinition, definition)
 		jumpAssert(pool.typeCheck(component))
 	end
@@ -807,7 +807,7 @@ function Registry:replaceComponent(entity, definition, component)
 	local pool = self._pools[definition]
 
 	if DEBUG then
-		jumpAssert(self:entityIsValid(entity), ErrInvalidEntity, entity)
+		jumpAssert(self:entityIsValid(entity))
 		jumpAssert(pool, ErrBadComponentDefinition, definition)
 		jumpAssert(pool.typeCheck(component))
 		jumpAssert(pool:getIndex(entity), ErrMissingComponent, entity, definition)
@@ -838,7 +838,7 @@ function Registry:addOrReplaceComponent(entity, definition, component)
 	local pool = self._pools[definition]
 
 	if DEBUG then
-		jumpAssert(self:entityIsValid(entity), ErrInvalidEntity, entity)
+		jumpAssert(self:entityIsValid(entity))
 		jumpAssert(pool, ErrBadComponentDefinition, definition)
 		jumpAssert(pool.typeCheck(component))
 	end
@@ -876,7 +876,7 @@ function Registry:addAndReplaceComponent(entity, definition, component)
 	local pool = self._pools[definition]
 
 	if DEBUG then
-		jumpAssert(self:entityIsValid(entity), ErrInvalidEntity, entity)
+		jumpAssert(self:entityIsValid(entity))
 		jumpAssert(pool, ErrBadComponentDefinition, definition)
 		jumpAssert(not pool:getIndex(entity), ErrAlreadyHasComponent, entity, definition)
 		jumpAssert(pool.typeCheck(component))
@@ -904,7 +904,7 @@ function Registry:removeComponent(entity, definition)
 	local pool = self._pools[definition]
 
 	if DEBUG then
-		jumpAssert(self:entityIsValid(entity), ErrInvalidEntity, entity)
+		jumpAssert(self:entityIsValid(entity))
 		jumpAssert(pool, ErrBadComponentDefinition, definition)
 		jumpAssert(pool:getIndex(entity), ErrMissingComponent, entity, definition)
 	end

--- a/lib/src/World/Registry.spec.lua
+++ b/lib/src/World/Registry.spec.lua
@@ -107,7 +107,7 @@ return function()
 
 	describe("createEntityFrom", function()
 		it("should return an entity identifier equal to hint when hint's entity id is not in use", function(context)
-			expect(context.registry:createEntityFrom(0xDEADBEEF)).to.equal(0xDEADBEEF)
+			expect(context.registry:createEntityFrom(0x0EADBEEF)).to.equal(0x0EADBEEF)
 		end)
 
 		it("should return an entity identifier equal to hint when hint's entity id has been recycled", function(context)

--- a/lib/src/World/Registry.spec.lua
+++ b/lib/src/World/Registry.spec.lua
@@ -107,7 +107,7 @@ return function()
 
 	describe("createEntityFrom", function()
 		it("should return an entity identifier equal to hint when hint's entity id is not in use", function(context)
-			expect(context.registry:createEntityFrom(0x0EADBEEF)).to.equal(0x0EADBEEF)
+			expect(context.registry:createEntityFrom(0xDEADBEEE)).to.equal(0xDEADBEEE)
 		end)
 
 		it("should return an entity identifier equal to hint when hint's entity id has been recycled", function(context)

--- a/lib/src/World/Registry.spec.lua
+++ b/lib/src/World/Registry.spec.lua
@@ -250,10 +250,8 @@ return function()
 			expect(registry:entityIsValid(NULL_ENTITYID)).to.equal(false)
 		end)
 
-		it("should error if the entity is not a number", function(context)
-			expect(function()
-				context.registry:entityIsValid("entity")
-			end).to.throw()
+		it("should return false if the entity is not a number", function(context)
+			expect(context.registry:entityIsValid("entity")).to.equal(false)
 		end)
 	end)
 


### PR DESCRIPTION
- `registry._entities` is now a dictionary
- Entity ID's first bit now indicates whether it originated on client or on server