### PR TITLE
Implement plugin component copying

### DIFF
--- a/plugin/src/Actions/OpenComponentMenu.lua
+++ b/plugin/src/Actions/OpenComponentMenu.lua
@@ -1,6 +1,7 @@
-return function(name)
+return function(isMenuOpen, name)
 	return {
 		type = "OpenComponentMenu",
+		isMenuOpen = isMenuOpen,
 		component = name,
 	}
 end

--- a/plugin/src/ComponentManager/ComponentAnnotation.lua
+++ b/plugin/src/ComponentManager/ComponentAnnotation.lua
@@ -11,10 +11,6 @@ local INSTANCE_REF_FOLDER = Constants.InstanceRefFolder
 local ComponentAnnotation = {}
 
 local function getDefaultAttributeMap(instance, definition)
-	if definition.pluginType then
-		definition = { name = definition.name, type = definition.pluginType }
-	end
-
 	local defaultSuccess, default = definition.type:tryDefault()
 
 	if not defaultSuccess and not definition.type.typeName == "none" then
@@ -27,10 +23,16 @@ local function getDefaultAttributeMap(instance, definition)
 end
 
 function ComponentAnnotation.apply(instance, definition, value)
+	if definition.pluginType then
+		definition = { name = definition.name, type = definition.pluginType }
+	end
+
 	local success, attributeMap
+	local usingDefault = false
 
 	if value == nil then
 		success, attributeMap = getDefaultAttributeMap(instance, definition)
+		usingDefault = true
 
 		if not success then
 			return false, attributeMap
@@ -45,8 +47,10 @@ function ComponentAnnotation.apply(instance, definition, value)
 
 	for attributeName, attributeValue in pairs(attributeMap) do
 		if typeof(attributeValue) == "Instance" then
-			attributeValue.Parent = workspace.Terrain
-			attributeValue.Archivable = false
+			if usingDefault then
+				attributeValue.Parent = workspace.Terrain
+				attributeValue.Archivable = false
+			end
 
 			instance[INSTANCE_REF_FOLDER][attributeName].Value = attributeValue
 		elseif attributeName ~= ENTITY_ATTRIBUTE_NAME then

--- a/plugin/src/ComponentManager/ComponentAnnotation.lua
+++ b/plugin/src/ComponentManager/ComponentAnnotation.lua
@@ -10,7 +10,7 @@ local INSTANCE_REF_FOLDER = Constants.InstanceRefFolder
 
 local ComponentAnnotation = {}
 
-local function getAttributeMap(instance, definition)
+local function getDefaultAttributeMap(instance, definition)
 	if definition.pluginType then
 		definition = { name = definition.name, type = definition.pluginType }
 	end
@@ -26,11 +26,21 @@ local function getAttributeMap(instance, definition)
 	return attributeSuccess, attributeMap, default
 end
 
-function ComponentAnnotation.add(instance, definition)
-	local success, attributeMap = getAttributeMap(instance, definition)
+function ComponentAnnotation.apply(instance, definition, value)
+	local success, attributeMap
 
-	if not success then
-		return false, attributeMap
+	if value == nil then
+		success, attributeMap = getDefaultAttributeMap(instance, definition)
+
+		if not success then
+			return false, attributeMap
+		end
+	else
+		success, attributeMap = Dom.tryToAttributes(instance, 0, definition, value)
+
+		if not success then
+			return false, attributeMap
+		end
 	end
 
 	for attributeName, attributeValue in pairs(attributeMap) do
@@ -50,7 +60,7 @@ function ComponentAnnotation.add(instance, definition)
 end
 
 function ComponentAnnotation.remove(instance, definition)
-	local success, attributeMap = getAttributeMap(instance, definition)
+	local success, attributeMap = getDefaultAttributeMap(instance, definition)
 
 	if not success then
 		return false, attributeMap

--- a/plugin/src/ComponentManager/init.lua
+++ b/plugin/src/ComponentManager/init.lua
@@ -4,6 +4,7 @@ local Selection = game:GetService("Selection")
 local ChangeHistory = game:GetService("ChangeHistoryService")
 
 local Modules = script.Parent.Parent
+local Llama = require(Modules.Llama)
 local Types = require(Modules.Anatta.Library.Types)
 local Dom = require(Modules.Anatta.Library.Dom)
 local Constants = require(Modules.Anatta.Library.Core.Constants)
@@ -613,8 +614,8 @@ function ComponentManager:DelComponent(name: string)
 	ChangeHistory:SetWaypoint(string.format("Deleted component %q", name))
 end
 
-function ComponentManager:SetComponent(component, value: boolean)
-	if value then
+function ComponentManager:SetComponent(component, has: boolean, value)
+	if has then
 		ChangeHistory:SetWaypoint(string.format("Applying component %q to selection", component.Name))
 	else
 		ChangeHistory:SetWaypoint(string.format("Removing component %q from selection", component.Name))
@@ -630,8 +631,12 @@ function ComponentManager:SetComponent(component, value: boolean)
 			continue
 		end
 
-		if value then
-			local success, err = ComponentAnnotation.apply(linkedInstance, definition)
+		if has then
+			local success, err = ComponentAnnotation.apply(
+				linkedInstance,
+				definition,
+				value ~= Llama.None and value or nil
+			)
 
 			if not success then
 				warn(err)
@@ -666,7 +671,7 @@ function ComponentManager:SetComponent(component, value: boolean)
 	-- to be manually marked for update.
 	self:_updateStore()
 
-	if value then
+	if has then
 		ChangeHistory:SetWaypoint(string.format("Applied component %q to selection", component.Name))
 	else
 		ChangeHistory:SetWaypoint(string.format("Removed component %q from selection", component.Name))

--- a/plugin/src/ComponentManager/init.lua
+++ b/plugin/src/ComponentManager/init.lua
@@ -631,7 +631,7 @@ function ComponentManager:SetComponent(component, value: boolean)
 		end
 
 		if value then
-			local success, err = ComponentAnnotation.add(linkedInstance, definition)
+			local success, err = ComponentAnnotation.apply(linkedInstance, definition)
 
 			if not success then
 				warn(err)

--- a/plugin/src/Components/ComponentList/Component.lua
+++ b/plugin/src/Components/ComponentList/Component.lua
@@ -40,11 +40,7 @@ function Component:render()
 
 		local isMenuOpen = self.state.isMenuOpen
 
-		if not isMenuOpen then
-			props.openComponentMenu(props.Component)
-		else
-			props.openComponentMenu(nil)
-		end
+		props.openComponentMenu(not isMenuOpen, props.Component)
 
 		self:setState({
 			isMenuOpen = not isMenuOpen,
@@ -108,8 +104,8 @@ end
 
 local function mapDispatchToProps(dispatch)
 	return {
-		openComponentMenu = function(component)
-			dispatch(Actions.OpenComponentMenu(component))
+		openComponentMenu = function(isMenuOpen, component)
+			dispatch(Actions.OpenComponentMenu(isMenuOpen, component))
 		end,
 		showContextMenu = function(component)
 			PluginGlobals.showComponentMenu(dispatch, component)

--- a/plugin/src/Components/ComponentList/ComponentValues/init.lua
+++ b/plugin/src/Components/ComponentList/ComponentValues/init.lua
@@ -3,10 +3,7 @@ local ChangeHistoryService = game:GetService("ChangeHistoryService")
 local Modules = script.Parent.Parent.Parent.Parent
 local Properties = script.Parent.Parent.Properties
 local Roact = require(Modules.Roact)
-local RoactRodux = require(Modules.RoactRodux)
-local Actions = require(Modules.Plugin.Actions)
 local Anatta = require(Modules.Anatta)
-local PluginGlobals = require(Modules.Plugin.PluginGlobals)
 
 local Boolean = require(Properties.Boolean)
 local EnumItem = require(Properties.EnumItem)
@@ -242,50 +239,5 @@ function ComponentValues:render()
 
 	return Roact.createElement(VerticalExpandingList, {}, members)
 end
-
-local function mapStateToProps(state)
-	local icon
-	local drawType
-	local color
-	local alwaysOnTop = false
-	for _, v in pairs(state.ComponentData) do
-		if v.Name == state.ComponentMenu then
-			icon = v.Icon
-			drawType = v.DrawType or "Box"
-			color = v.Color
-			alwaysOnTop = v.AlwaysOnTop
-		end
-	end
-
-	return {
-		componentMenu = state.ComponentMenu,
-		componentIcon = icon or "component_green",
-		componentColor = color,
-		componentDrawType = drawType,
-		componentAlwaysOnTop = alwaysOnTop,
-	}
-end
-
-local function mapDispatchToProps(dispatch)
-	return {
-		close = function()
-			dispatch(Actions.OpenComponentMenu(nil))
-		end,
-		iconPicker = function(componentMenu)
-			dispatch(Actions.ToggleIconPicker(componentMenu))
-		end,
-		colorPicker = function(componentMenu)
-			PluginGlobals.promptPickColor(dispatch, componentMenu)
-		end,
-		groupPicker = function(componentMenu)
-			dispatch(Actions.ToggleGroupPicker(componentMenu))
-		end,
-		instanceView = function(componentMenu)
-			dispatch(Actions.OpenInstanceView(componentMenu))
-		end,
-	}
-end
-
-ComponentValues = RoactRodux.connect(mapStateToProps, mapDispatchToProps)(ComponentValues)
 
 return ComponentValues

--- a/plugin/src/Main.lua
+++ b/plugin/src/Main.lua
@@ -1,3 +1,5 @@
+local Selection = game:GetService("Selection")
+
 local Modules = script.Parent.Parent
 local Roact = require(Modules.Roact)
 local Rodux = require(Modules.Rodux)
@@ -22,6 +24,7 @@ end
 
 return function(plugin, savedState)
 	local displaySuffix, nameSuffix = getSuffix(plugin)
+	local componentClipboard = {}
 
 	local toolbar = plugin:toolbar("Anatta" .. displaySuffix)
 
@@ -39,7 +42,52 @@ return function(plugin, savedState)
 		"http://www.roblox.com/asset/?id=1367285594"
 	)
 
+	local copyButton = plugin:button(toolbar, "Copy Components", "Copy components from a selected instance.", "")
+
+	local pasteButton = plugin:button(
+		toolbar,
+		"Paste Components",
+		"Paste currently copied components onto selected instances.",
+		""
+	)
+
 	local store = Rodux.Store.new(Reducer, savedState)
+
+	local function copyComponents()
+		local selected = Selection:Get()
+
+		if #selected > 1 then
+			error("Cannot copy components from more than one instance")
+		elseif #selected == 0 then
+			error("No instance selected")
+		end
+
+		componentClipboard = {}
+
+		local state = store:getState()
+		local openMenus = state.ComponentMenu
+		local components = ComponentManager.Get().components
+
+		for _, component in ipairs(components) do
+			if not openMenus[component.Name] then
+				continue
+			end
+
+			local _, value = next(component.Values)
+
+			if value then
+				componentClipboard[component] = value
+			end
+		end
+
+		print(componentClipboard)
+	end
+
+	local function pasteComponents()
+		for component, value in pairs(componentClipboard) do
+			ComponentManager.Get():SetComponent(component, true, value)
+		end
+	end
 
 	local manager = ComponentManager.new(store)
 
@@ -61,6 +109,9 @@ return function(plugin, savedState)
 		gui.Enabled = not gui.Enabled
 		toggleButton:SetActive(gui.Enabled)
 	end)
+
+	local pasteConnection = pasteButton.Click:Connect(pasteComponents)
+	local copyConnection = copyButton.Click:Connect(copyComponents)
 
 	local prefix = "ComponentEditor" .. nameSuffix .. "_"
 
@@ -118,6 +169,22 @@ return function(plugin, savedState)
 			ComponentManager.Get():SelectAll(component.Definition.name)
 		end
 	end)
+
+	local copyAction = plugin:createAction(
+		prefix .. "CopyComponents",
+		"Copy components",
+		"Copy components from a selected instance."
+	)
+
+	local copyActionConnection = copyAction.Triggered:Connect(copyComponents)
+
+	local pasteAction = plugin:createAction(
+		prefix .. "PasteComponents",
+		"Paste components",
+		"Paste currently copied components onto selected instances."
+	)
+
+	local pasteActionConnection = pasteAction.Triggered:Connect(pasteComponents)
 
 	local visualizeBox = plugin:createAction(
 		prefix .. "Visualize_Box",
@@ -202,6 +269,10 @@ return function(plugin, savedState)
 	plugin:beforeUnload(function()
 		Roact.unmount(instance)
 		connection:Disconnect()
+		copyActionConnection:Disconnect()
+		copyConnection:Disconnect()
+		pasteActionConnection:Disconnect()
+		pasteConnection:Disconnect()
 		worldViewConnection:Disconnect()
 		manager:Destroy()
 		selectAllConn:Disconnect()

--- a/plugin/src/Main.lua
+++ b/plugin/src/Main.lua
@@ -79,8 +79,6 @@ return function(plugin, savedState)
 				componentClipboard[component] = value
 			end
 		end
-
-		print(componentClipboard)
 	end
 
 	local function pasteComponents()

--- a/plugin/src/Reducer/ComponentMenu.lua
+++ b/plugin/src/Reducer/ComponentMenu.lua
@@ -1,8 +1,11 @@
+local Llama = require(script.Parent.Parent.Parent.Llama)
+
 return function(state, action)
-	state = state or nil
+	state = state or {}
 
 	if action.type == "OpenComponentMenu" then
-		return action.component
+		local value = if action.isMenuOpen then action.component else Llama.None
+		state = Llama.Dictionary.merge(state, { [action.component.Name] = value })
 	end
 
 	return state


### PR DESCRIPTION
This PR adds the ability to copy components using the Anatta plugin. Using the copy action copies all expanded components on one selected instance to the clipboard. The paste action applies all components on the clipboard to selected instances.