### PR TITLE
Fix default union creation

### DIFF
--- a/lib/src/Core/T.lua
+++ b/lib/src/Core/T.lua
@@ -357,11 +357,9 @@ end
 
 function TypeDefinition:tryDefault()
 	local default = defaults[self.typeName]
-	local success, concreteType
+	local success, concreteType = self:tryGetConcreteType()
 
-	if not default then
-		success, concreteType = self:tryGetConcreteType()
-
+	if default == nil then
 		if not success then
 			return false, concreteType
 		end

--- a/lib/src/Core/T.spec.lua
+++ b/lib/src/Core/T.spec.lua
@@ -91,7 +91,8 @@ return function()
 				local success, default = T.union(T.instanceOf("Trail"), T.instanceOf("Beam")):tryDefault()
 
 				expect(success).to.equal(true)
-				expect(default).to.be.a("Trail")
+				expect(typeof(default)).to.equal("Instance")
+				expect(default:IsA("Trail")).to.equal(true)
 			end)
 
 			it("should correctly handle T.array", function()

--- a/lib/src/Core/T.spec.lua
+++ b/lib/src/Core/T.spec.lua
@@ -87,6 +87,13 @@ return function()
 				expect(default).to.equal("BIG")
 			end)
 
+			it("should correctly handle a T.union of instances", function()
+				local success, default = T.union(T.instanceOf("Trail"), T.instanceOf("Beam")):tryDefault()
+
+				expect(success).to.equal(true)
+				expect(default).to.be.a("Trail")
+			end)
+
 			it("should correctly handle T.array", function()
 				local ok, default = T.array(T.number):tryDefault()
 
@@ -149,9 +156,16 @@ return function()
 					T.literal("A"),
 					T.literal("Union")
 				)
+				local stringSuccess, stringUnionConcreteType = stringUnion:tryGetConcreteType()
 
-				local _, concreteType = stringUnion:tryGetConcreteType()
-				expect(concreteType).to.equal("literal")
+				expect(stringSuccess).to.equal(true)
+				expect(stringUnionConcreteType).to.equal("literal")
+
+				local instanceUnion = T.union(T.instanceOf("Beam"), T.instanceOf("Trail"))
+				local instanceSuccess, instanceUnionConcreteType = instanceUnion:tryGetConcreteType()
+
+				expect(instanceSuccess).to.equal(true)
+				expect(instanceUnionConcreteType).to.equal("instanceOf")
 			end)
 
 			it("should resolve an array", function()


### PR DESCRIPTION
We are currently using the concrete type to locate all default generators. This PR changes `TypeDefinition:tryDefault` so that it attempts to use the typename to find a default generator before trying the concrete type. 