### PR TITLE
Revert "Assign ZIndex to component values (#183)"

### DIFF
--- a/plugin/src/Components/ComponentList/ComponentValues/CollapsibleSection.lua
+++ b/plugin/src/Components/ComponentList/ComponentValues/CollapsibleSection.lua
@@ -16,7 +16,6 @@ function CollapsibleSection:render()
 		Collapsed = self.state.Collapsed,
 		HeaderText = self.props.HeaderText,
 		Key = self.props.Key,
-		ZIndex = self.props.ZIndex,
 	}, self.props[Roact.Children])
 end
 

--- a/plugin/src/Components/ComponentList/ComponentValues/init.lua
+++ b/plugin/src/Components/ComponentList/ComponentValues/init.lua
@@ -26,17 +26,12 @@ local INSTANCE_REF_FOLDER = Anatta.Constants.InstanceRefFolder
 
 local ComponentValues = Roact.Component:extend("ComponentValues")
 
-local CurrentZIndex = 1
-
 local function createInstanceElement(name, attributeName, typeDefinition, value, values)
 	local typeParam = typeDefinition.typeParams[1]
 
 	local currentInstance = if value and value.Parent and value.Parent ~= workspace.Terrain then value else nil
 
-	CurrentZIndex += 1
-
 	return Roact.createElement(InstanceSelect, {
-		ZIndex = -CurrentZIndex,
 		Key = name,
 		Instance = currentInstance,
 		IsA = typeDefinition.typeName == "instanceIsA" and typeParam,
@@ -56,10 +51,7 @@ end
 
 local function makeInputElement(elementKind)
 	return function(name, attributeName, _, value, linkedInstances)
-		CurrentZIndex += 1
-
 		return Roact.createElement(elementKind, {
-			ZIndex = -CurrentZIndex,
 			Key = name,
 			Value = value,
 			OnChanged = function(newValue)
@@ -80,10 +72,7 @@ local function makeInputElement(elementKind)
 end
 
 local function createArrayAddElement(attributeName, typeDefinition, value, linkedInstances, indentCount)
-	CurrentZIndex += 1
-
 	return Roact.createElement(InlineButton, {
-		ZIndex = -CurrentZIndex,
 		Key = attributeName,
 		Text = "+ Add Item",
 		Indents = indentCount,
@@ -141,10 +130,7 @@ local Types = {
 			table.insert(enums, { Name = itemName })
 		end
 
-		CurrentZIndex += 1
-
 		return Roact.createElement(EnumItem, {
-			ZIndex = -CurrentZIndex,
 			Key = name,
 			Enum = mockEnum,
 			Selected = {
@@ -163,10 +149,7 @@ local Types = {
 	end,
 
 	entity = function(name, attributeName, _, _, values)
-		CurrentZIndex += 1
-
 		return Roact.createElement(InstanceSelect, {
-			ZIndex = -CurrentZIndex,
 			Key = name,
 			OnChanged = function(instance)
 				ChangeHistoryService:SetWaypoint(("Changing attribute %s"):format(attributeName))
@@ -256,12 +239,9 @@ local function createComponentMembers(
 				return lhs.props.Key < rhs.props.Key
 			end)
 
-			CurrentZIndex += 1
-
 			table.insert(
 				members,
 				Roact.createElement(CollapsibleSection, {
-					ZIndex = -CurrentZIndex + 10000,
 					Key = ("%s%s"):format(string.rep("  ", recursedCount), name),
 					HeaderText = ("%s%s"):format(string.rep("  ", recursedCount), name),
 					OnToggled = function() end,
@@ -317,8 +297,6 @@ function ComponentValues:render()
 	local name = definition.name
 	local typeDefinition = definition.pluginType and definition.pluginType or definition.type
 	local _, value = next(props.Values)
-
-	CurrentZIndex = 1
 
 	-- TODO: compare all values to display ambiguous fields
 	local members = createComponentMembers(name, name, typeDefinition, value, props.Values)

--- a/plugin/src/Components/Properties/Boolean.lua
+++ b/plugin/src/Components/Properties/Boolean.lua
@@ -17,7 +17,6 @@ function Boolean:render()
 
 	return Roact.createElement(BaseProperty, {
 		Text = props.Key,
-		ZIndex = props.ZIndex,
 	}, {
 		Centered = Roact.createElement("Frame", {
 			Size = UDim2.new(1, 0, 0, 15),

--- a/plugin/src/Components/Properties/ComplexStringInput.lua
+++ b/plugin/src/Components/Properties/ComplexStringInput.lua
@@ -45,7 +45,6 @@ end
 
 function ComplexStringInput:render()
 	return Roact.createElement(StringInput, {
-		ZIndex = self.props.ZIndex,
 		_FieldRef = self.fieldRef,
 		Value = self.props.Value,
 		Key = self.props.Key,

--- a/plugin/src/Components/Properties/EnumItem.lua
+++ b/plugin/src/Components/Properties/EnumItem.lua
@@ -13,7 +13,7 @@ local function EnumItem(props)
 
 	return Roact.createElement(BaseProperty, {
 		Text = props.Key,
-		ZIndex = props.ZIndex,
+		ZIndex = 100,
 	}, {
 		Centered = Roact.createElement("Frame", {
 			Size = UDim2.new(1, 0, 0, 15),

--- a/plugin/src/Components/Properties/EnumSelect.lua
+++ b/plugin/src/Components/Properties/EnumSelect.lua
@@ -13,14 +13,12 @@ local function EnumSelect(props)
 
 	return Roact.createElement(BaseProperty, {
 		Text = props.Key,
-		ZIndex = props.ZIndex,
 	}, {
 		Centered = Roact.createElement("Frame", {
 			Size = UDim2.new(1, 0, 0, 15),
 			BackgroundTransparency = 1,
 			AnchorPoint = Vector2.new(0, 0.5),
 			Position = UDim2.new(0, 0, 0.5, 0),
-			ZIndex = props.ZIndex,
 		}, {
 			Dropdown = Roact.createElement(StudioComponents.Dropdown, {
 				Items = items,

--- a/plugin/src/Components/Properties/InstanceSelect.lua
+++ b/plugin/src/Components/Properties/InstanceSelect.lua
@@ -30,7 +30,6 @@ function InstanceSelect:render()
 
 	return Roact.createElement(BaseProperty, {
 		Text = ("%s (%s)"):format(self.props.Key, requiredKind or "any"),
-		ZIndex = self.props.ZIndex,
 	}, {
 		InstanceSelector = Roact.createElement(StudioComponents.Button, {
 			Size = UDim2.new(1, 0, 1, 0),

--- a/plugin/src/Components/Properties/IntegerInput.lua
+++ b/plugin/src/Components/Properties/IntegerInput.lua
@@ -7,7 +7,6 @@ local function IntegerInput(props)
 	return Roact.createElement(ComplexStringInput, {
 		Key = props.Key,
 		Value = props.Value,
-		ZIndex = props.ZIndex,
 
 		Filter = function(raw)
 			return raw:match("%d*%.?%d*")

--- a/plugin/src/Components/Properties/NumberInput.lua
+++ b/plugin/src/Components/Properties/NumberInput.lua
@@ -7,7 +7,6 @@ local function NumberInput(props)
 	return Roact.createElement(ComplexStringInput, {
 		Key = props.Key,
 		Value = props.Value,
-		ZIndex = props.ZIndex,
 
 		Filter = function(raw)
 			return raw:match("%-?%d*%.?%d*")

--- a/plugin/src/Components/Properties/StringInput.lua
+++ b/plugin/src/Components/Properties/StringInput.lua
@@ -7,7 +7,6 @@ local BaseProperty = require(script.Parent.BaseProperty)
 local function StringInput(props)
 	return Roact.createElement(BaseProperty, {
 		Text = props.Key,
-		ZIndex = props.ZIndex,
 	}, {
 		Container = Roact.createElement("Frame", {
 			[Roact.Ref] = props._FieldRef,

--- a/plugin/src/Components/Properties/UDim2Input.lua
+++ b/plugin/src/Components/Properties/UDim2Input.lua
@@ -25,7 +25,6 @@ local function UDim2Input(props)
 	return Roact.createElement(ComplexStringInput, {
 		Key = props.Key,
 		Value = createShortStringFromUDim2(props.Value),
-		ZIndex = props.ZIndex,
 
 		Validate = function(raw)
 			local udim2 = createUDim2FromString(raw:gsub("%s", ""))

--- a/plugin/src/Components/Properties/UDimInput.lua
+++ b/plugin/src/Components/Properties/UDimInput.lua
@@ -23,7 +23,6 @@ local function UDimInput(props)
 	return Roact.createElement(ComplexStringInput, {
 		Key = props.Key,
 		Value = createShortStringFromUDim(props.Value),
-		ZIndex = props.ZIndex,
 
 		Validate = function(raw)
 			local udim = createUDimFromString(raw:gsub("%s", ""))

--- a/plugin/src/Components/Properties/Vector2Input.lua
+++ b/plugin/src/Components/Properties/Vector2Input.lua
@@ -23,7 +23,6 @@ local function Vector2Input(props)
 	return Roact.createElement(ComplexStringInput, {
 		Key = props.Key,
 		Value = createShortStringFromVector2(props.Value),
-		ZIndex = props.ZIndex,
 
 		Validate = function(raw)
 			local vec2 = createVector2FromString(raw:gsub("%s", ""))

--- a/plugin/src/Components/Properties/Vector3Input.lua
+++ b/plugin/src/Components/Properties/Vector3Input.lua
@@ -23,7 +23,6 @@ local function Vector3Input(props)
 	return Roact.createElement(ComplexStringInput, {
 		Key = props.Key,
 		Value = createShortStringFromVector3(props.Value),
-		ZIndex = props.ZIndex,
 
 		Validate = function(raw)
 			local vec3 = createVector3FromString(raw:gsub("%s", ""))


### PR DESCRIPTION
This reverts commit 4ac4c15d7ded90ed83a5dfdaf20d307e57ace0ef. The problem of overlapping elements are solved by #176.